### PR TITLE
PFP-6163 SVP Innvilgelsebrev bugfix

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseSvangerskapspengerBrevMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseSvangerskapspengerBrevMapper.java
@@ -56,8 +56,8 @@ public class InnvilgelseSvangerskapspengerBrevMapper extends FritekstmalBrevMapp
         BeregningsresultatFP beregningsresultatFP = domeneobjektProvider.hentBeregningsresultatFP(behandling);
         SvpUttaksresultat svpUttaksresultat = domeneobjektProvider.hentUttaksresultatSvp(behandling);
 
-        svpUttaksresultat = SvpMapper.utvidOgTilpassBrev(svpUttaksresultat, beregningsresultatFP);
         Map<String, Object> beregning = SvpMapper.mapFra(svpUttaksresultat, hendelse, beregningsgrunnlag, beregningsresultatFP, behandling);
+        svpUttaksresultat = SvpMapper.utvidOgTilpassBrev(svpUttaksresultat, beregningsresultatFP);
 
         return new Brevdata()
                 .leggTil("resultat", svpUttaksresultat)


### PR DESCRIPTION
- Midlertidig fiks ved å bytte om på rekkefølgen til to mapping-metode kall.
  Den ene er deprecated og skal uansett fjernes.