### PR TITLE
TFP-2195 Rettet at innvilgesebrev på svangerskapspenger henter brutto…

### DIFF
--- a/dokumentlager/domene/src/main/java/no/nav/foreldrepenger/melding/beregningsgrunnlag/BeregningsgrunnlagPeriode.java
+++ b/dokumentlager/domene/src/main/java/no/nav/foreldrepenger/melding/beregningsgrunnlag/BeregningsgrunnlagPeriode.java
@@ -12,6 +12,7 @@ public class BeregningsgrunnlagPeriode {
     private Long dagsats;
     private BigDecimal bruttoPrÅr;
     private BigDecimal redusertPrÅr;
+    private BigDecimal avkortetPrÅr;
     private List<String> periodeÅrsakKoder;
     private DatoIntervall periode;
     private List<BeregningsgrunnlagPrStatusOgAndel> beregningsgrunnlagPrStatusOgAndelList = new ArrayList<>();
@@ -23,6 +24,7 @@ public class BeregningsgrunnlagPeriode {
         dagsats = builder.dagsats;
         bruttoPrÅr = builder.bruttoPrÅr;
         redusertPrÅr = builder.redusertPrÅr;
+        avkortetPrÅr = builder.avkortetPrÅr;
         periodeÅrsakKoder = builder.periodeÅrsaker;
         periode = builder.periode;
         beregningsgrunnlagPrStatusOgAndelList = builder.beregningsgrunnlagPrStatusOgAndelList;
@@ -48,6 +50,8 @@ public class BeregningsgrunnlagPeriode {
         return redusertPrÅr;
     }
 
+    public BigDecimal getAvkortetPrÅr() { return avkortetPrÅr;
+    }
     public LocalDate getBeregningsgrunnlagPeriodeFom() {
         return periode.getFomDato();
     }
@@ -64,6 +68,7 @@ public class BeregningsgrunnlagPeriode {
         private Long dagsats;
         private BigDecimal bruttoPrÅr;
         private BigDecimal redusertPrÅr;
+        private BigDecimal avkortetPrÅr;
         private List<String> periodeÅrsaker;
         private DatoIntervall periode;
         private List<BeregningsgrunnlagPrStatusOgAndel> beregningsgrunnlagPrStatusOgAndelList;
@@ -83,6 +88,11 @@ public class BeregningsgrunnlagPeriode {
 
         public Builder medRedusertPrÅr(BigDecimal val) {
             redusertPrÅr = val;
+            return this;
+        }
+
+        public Builder medAvkortetPrÅr(BigDecimal val) {
+            avkortetPrÅr = val;
             return this;
         }
 

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/BeregningsgrunnlagMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/BeregningsgrunnlagMapper.java
@@ -195,6 +195,10 @@ public class BeregningsgrunnlagMapper {
     public static boolean inntektOverSeksG(Beregningsgrunnlag beregningsgrunnlag) {
         return finnFørstePeriode(beregningsgrunnlag).getBruttoPrÅr().compareTo(finnSeksG(beregningsgrunnlag)) > 0;
     }
+    //kun SVP: avkortetPerÅr gir faktisk beregningsgrunnlag for alle arbeidsforhold, og ikke bare arbeidsforholdet det søkes om - en verdi kun på dto
+    public static BigDecimal getAvkortetPrAarSVP(Beregningsgrunnlag beregningsgrunnlag) {
+        return finnFørstePeriode(beregningsgrunnlag).getAvkortetPrÅr();
+    }
 
     static StatusTypeKode tilStatusTypeKode(AktivitetStatus statuskode) {
         if (aktivitetStatusKodeStatusTypeKodeMap.containsKey(statuskode)) {

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/svp/SvpMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/svp/SvpMapper.java
@@ -60,7 +60,7 @@ public class SvpMapper {
         Map<String, Object> map = new HashMap<>(mapAtFlSnForholdFra(beregningsgrunnlag));
         map.putAll(mapAktiviteter(svpUttaksresultat, beregningsresultat, beregningsgrunnlag));
         map.put("nyEllerEndretBeregning", erNyEllerEndretBeregning(behandling));
-        map.put("bruttoBeregningsgrunnlag", BeregningsgrunnlagMapper.finnBrutto(beregningsgrunnlag));
+        map.put("bruttoBeregningsgrunnlag", BeregningsgrunnlagMapper.getAvkortetPrAarSVP(beregningsgrunnlag));
         map.put("militarSivil", BeregningsgrunnlagMapper.militærEllerSivilTjeneste(beregningsgrunnlag));
         map.put("inntektOver6G", BeregningsgrunnlagMapper.inntektOverSeksG(beregningsgrunnlag));
         map.put("seksG", BeregningsgrunnlagMapper.finnSeksG(beregningsgrunnlag).intValue());

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/domene/BeregningsgrunnlagMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/domene/BeregningsgrunnlagMapperTest.java
@@ -35,6 +35,7 @@ public class BeregningsgrunnlagMapperTest {
         return BeregningsgrunnlagPeriode.ny()
                 .medDagsats(STANDARD_PERIODE_DAGSATS)
                 .medBruttoPrÅr(BRUTTO_PR_ÅR)
+                .medAvkortetPrÅr(AVKORTET_PR_ÅR)
                 .medBeregningsgrunnlagPrStatusOgAndelList(lagBgpsaListe())
                 .build();
     }
@@ -74,6 +75,11 @@ public class BeregningsgrunnlagMapperTest {
     @Test
     public void skal_finne_brutto() {
         assertThat(BeregningsgrunnlagMapper.finnBrutto(beregningsgrunnlag)).isEqualTo(BRUTTO_PR_ÅR.add(AVKORTET_PR_ÅR).longValue());
+    }
+
+    @Test
+    public void skal_finne_avkortetPrÅr_SVP() {
+        assertThat(BeregningsgrunnlagMapper.getAvkortetPrAarSVP(beregningsgrunnlag)).isEqualTo(AVKORTET_PR_ÅR);
     }
 
     @Test

--- a/integrasjon/dtomapper/src/main/java/no/nav/foreldrepenger/melding/dtomapper/BeregningsgrunnlagDtoMapper.java
+++ b/integrasjon/dtomapper/src/main/java/no/nav/foreldrepenger/melding/dtomapper/BeregningsgrunnlagDtoMapper.java
@@ -83,6 +83,7 @@ public class BeregningsgrunnlagDtoMapper {
         return BeregningsgrunnlagPeriode.ny()
                 .medBruttoPrÅr(dto.getBruttoPrAar())
                 .medRedusertPrÅr(dto.getRedusertPrAar())
+                .medAvkortetPrÅr(dto.getAvkortetPrAar())
                 .medDagsats(dto.getDagsats())
                 .medPeriode(intervall)
                 .medperiodeÅrsaker(dto.getPeriodeAarsaker().stream().map(KodeDto::getKode).collect(Collectors.toList()))


### PR DESCRIPTION
…berergningsgrunnlag fra beregningsgrunnlagperiodens avkortetPerÅr, og ikke fra beregningsgrunnlagperstatusogandel. Dette fordi at avkortet beløp på statusOgAndel for svp er det som bruker faktisk har søkt om, og ikke beregningsgrunnlag for alle arbeidsforhold som er det som ønskes kommunisert til bruker. Her er det ulikt for foreldrepenger og svangerskapspenger.