### PR TITLE
TFP-2178 Rettet slik at både annenForelderHarRett og annenForelderHar…

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseForeldrepengerMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseForeldrepengerMapper.java
@@ -196,7 +196,6 @@ public class InnvilgelseForeldrepengerMapper extends DokumentTypeMapper {
         }
         fagType.setAleneomsorg(aleneomsorg);
 
-        //Nytt felt for å angi ikke vurdert når saksbehandler aldri har vurdert rettighet for annen part. I dette tilfellet skal ikke tekst vises
         VurderingsstatusKode annenForelderHarRettVurdert;
         if (aksjonspunkter.stream().
                 filter(ap -> Objects.equals(ap.getAksjonspunktDefinisjon(), AksjonspunktDefinisjon.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_IKKE_RETT)).
@@ -206,7 +205,9 @@ public class InnvilgelseForeldrepengerMapper extends DokumentTypeMapper {
         else {
             annenForelderHarRettVurdert = VurderingsstatusKode.IKKE_VURDERT;
         }
+        //Begge felt brukes for å skille på overstyrt rettighet og ikke
         fagType.setAnnenForelderHarRettVurdert(annenForelderHarRettVurdert);
+        fagType.setAnnenForelderHarRett(uttakResultatPerioder.isAnnenForelderHarRett());
     }
 
     private void mapFelterRelatertTilStønadskontoer(FagType fagType, UttakResultatPerioder uttakResultatPerioder, Saldoer saldoer, FamilieHendelse familieHendelse, Fagsak fagsak) {


### PR DESCRIPTION
…RettVurdert legges i bestillingsxml. Det er behov for begge for å vise riktig tekst både når rettighet annen forelder har rett er overstyrt av saksbehandler, og alle andre tilfeller