### PR TITLE
TFP-3049 Endret at behandlingstype for innhentingsbrev aldri kan være…

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/BehandlingMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/BehandlingMapper.java
@@ -56,10 +56,12 @@ public class BehandlingMapper {
         return gjelderEndringsøknad(behandling) ?
                 ENDRINGSSØKNAD :
                 behandling.getBehandlingType().getKode();
-    }
+        }
+
 
     public static boolean gjelderEndringsøknad(Behandling behandling) {
-        return getBehandlingÅrsakStringListe(behandling)
+        // endringssøknad kan være satt ved førstegangsbehandling og henleggelse pga håndtering av tapte dager
+        return behandling.erRevurdering() && getBehandlingÅrsakStringListe(behandling)
                 .contains(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER.getKode());
     }
 

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/brev/InnhentOpplysningerBrevMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/brev/InnhentOpplysningerBrevMapperTest.java
@@ -53,6 +53,7 @@ public class InnhentOpplysningerBrevMapperTest {
     public void setup() {
         brevMapper = new InnhentOpplysningerBrevMapper(DatamapperTestUtil.getBrevParametere(), null);
         doReturn(BehandlingType.FØRSTEGANGSSØKNAD).when(behandling).getBehandlingType();
+
     }
 
     @Test
@@ -98,6 +99,7 @@ public class InnhentOpplysningerBrevMapperTest {
 
     @Test
     public void skal_velge_siste_mottatt_dato_fra_endringssøknad_når_endring() {
+        doReturn(Boolean.TRUE).when(behandling).erRevurdering();
         doReturn(List.of(opprettBehandlingsårsak(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER.getKode()))).when(behandling).getBehandlingÅrsaker();
         LocalDate andreJanuar = LocalDate.of(2019, 1, 2);
         LocalDate fjerdeJanuar = LocalDate.of(2019, 1, 4);


### PR DESCRIPTION
… Endringssøknad dersom behandlingen ikke er en revurdering. Dette fordi førstegangsbehandlinger merkes med behandlingsårsak=endringssøknad ved henleggelse (har noe med håndtering av tapte dager å gjøre). Nå får brevet riktig tekst. På sikt må dette rettes i fpsak.