### PR TITLE
TFP-3929 Rettet at innvilgelsebrev foreldrepenger feilet når arbeidsg…

### DIFF
--- a/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/dto/beregning/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.java
+++ b/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/dto/beregning/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import no.nav.foreldrepenger.fpsak.dto.kodeverk.KodeDto;
+import no.nav.foreldrepenger.melding.typer.AktørId;
 
 public class BeregningsgrunnlagArbeidsforholdDto {
 
@@ -13,7 +14,7 @@ public class BeregningsgrunnlagArbeidsforholdDto {
     private LocalDate opphoersdato;
     private String arbeidsforholdId;
     private KodeDto arbeidsforholdType;
-    private Long aktørId;
+    private AktørId aktørId;
     private BigDecimal naturalytelseBortfaltPrÅr;
     private BigDecimal naturalytelseTilkommetPrÅr;
 
@@ -69,11 +70,11 @@ public class BeregningsgrunnlagArbeidsforholdDto {
         this.arbeidsforholdType = arbeidsforholdType;
     }
 
-    public void setAktørId(Long aktørId) {
+    public void setAktørId(AktørId aktørId) {
         this.aktørId = aktørId;
     }
 
-    public Long getAktørId() {
+    public AktørId getAktørId() {
         return aktørId;
     }
 

--- a/integrasjon/dtomapper/src/main/java/no/nav/foreldrepenger/melding/dtomapper/BeregningsgrunnlagDtoMapper.java
+++ b/integrasjon/dtomapper/src/main/java/no/nav/foreldrepenger/melding/dtomapper/BeregningsgrunnlagDtoMapper.java
@@ -57,7 +57,7 @@ public class BeregningsgrunnlagDtoMapper {
         AktørId aktørId = null;
         Virksomhet virksomhet = null;
         if (dto.getAktørId() != null) {
-            aktørId = new AktørId(dto.getAktørId());
+            aktørId = dto.getAktørId();
         } else {
             virksomhet = new Virksomhet(dto.getArbeidsgiverNavn(), dto.getArbeidsgiverId());
         }


### PR DESCRIPTION
…iver er privat(har aktør id og ikke orgnr). Klassen BeregningsgrunnlagArbeidsforholdDto forsøkte å mappe aktørId som long og ikke AktørId. Deserialisering feilet.