### PR TITLE
NOJIRA slett kodelister ny felles rydde etter enforce

### DIFF
--- a/dokumentlager/domene/pom.xml
+++ b/dokumentlager/domene/pom.xml
@@ -40,10 +40,6 @@
 
         <!-- Eksterne -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/dokumentlager/domene/src/test/resources/logback-test.xml
+++ b/dokumentlager/domene/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/dokumentproduksjon-klient/pom.xml
+++ b/dokumentproduksjon-klient/pom.xml
@@ -16,6 +16,12 @@
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>felles-integrasjon-webservice</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>no.nav.tjenester.fim</groupId>

--- a/dokumentproduksjon-klient/src/test/java/no/nav/foreldrepenger/melding/dokumentproduksjon/v2/DokumentProduksjonConsumerTest.java
+++ b/dokumentproduksjon-klient/src/test/java/no/nav/foreldrepenger/melding/dokumentproduksjon/v2/DokumentProduksjonConsumerTest.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.melding.dokumentproduksjon.v2;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -11,10 +12,11 @@ import javax.xml.soap.SOAPFactory;
 import javax.xml.soap.SOAPFault;
 import javax.xml.ws.soap.SOAPFaultException;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v2.binding.DokumentproduksjonV2;
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v2.meldinger.FerdigstillForsendelseRequest;
@@ -23,16 +25,15 @@ import no.nav.tjeneste.virksomhet.dokumentproduksjon.v2.meldinger.ProduserDokume
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v2.meldinger.ProduserIkkeredigerbartDokumentRequest;
 import no.nav.vedtak.exception.IntegrasjonException;
 
+@ExtendWith(MockitoExtension.class)
 public class DokumentProduksjonConsumerTest {
 
     private DokumentproduksjonConsumer consumer;
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    @Mock
+    private DokumentproduksjonV2 mockWebservice;
 
-    private DokumentproduksjonV2 mockWebservice = mock(DokumentproduksjonV2.class);
-
-    @Before
+    @BeforeEach
     public void setUp() {
         consumer = new DokumentproduksjonConsumerImpl(mockWebservice);
     }
@@ -41,40 +42,28 @@ public class DokumentProduksjonConsumerTest {
     public void skalKasteTekniskfeilNårWebserviceSenderSoapFault_ikkeRedigerbart() throws Exception {
         when(mockWebservice.produserIkkeredigerbartDokument(any(ProduserIkkeredigerbartDokumentRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.produserIkkeredigerbartDokument(mock(ProduserIkkeredigerbartDokumentRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.produserIkkeredigerbartDokument(mock(ProduserIkkeredigerbartDokumentRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilNårWebserviceSenderSoapFault_dokumentUtkast() throws Exception {
         when(mockWebservice.produserDokumentutkast(any(ProduserDokumentutkastRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.produserDokumentutkast(mock(ProduserDokumentutkastRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.produserDokumentutkast(mock(ProduserDokumentutkastRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilVedSoapFault_ferdigstillForsendelse() throws Exception {
         doThrow(opprettSOAPFaultException("feil")).when(mockWebservice).ferdigstillForsendelse(any(FerdigstillForsendelseRequest.class));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.ferdigstillForsendelse(mock(FerdigstillForsendelseRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.ferdigstillForsendelse(mock(FerdigstillForsendelseRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilVedSoapFault_knyttVedleggTilForsendelse() throws Exception {
         doThrow(opprettSOAPFaultException("feil")).when(mockWebservice).knyttVedleggTilForsendelse(any(KnyttVedleggTilForsendelseRequest.class));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.knyttVedleggTilForsendelse(mock(KnyttVedleggTilForsendelseRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.knyttVedleggTilForsendelse(mock(KnyttVedleggTilForsendelseRequest.class)));
     }
 
     private SOAPFaultException opprettSOAPFaultException(String faultString) throws SOAPException {

--- a/dokumentproduksjon-klient/src/test/java/no/nav/foreldrepenger/melding/dokumentproduksjon/v3/DokumentProduksjonConsumerTest.java
+++ b/dokumentproduksjon-klient/src/test/java/no/nav/foreldrepenger/melding/dokumentproduksjon/v3/DokumentProduksjonConsumerTest.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.melding.dokumentproduksjon.v3;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -11,10 +12,11 @@ import javax.xml.soap.SOAPFactory;
 import javax.xml.soap.SOAPFault;
 import javax.xml.ws.soap.SOAPFaultException;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v3.DokumentproduksjonV3;
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v3.meldinger.FerdigstillForsendelseRequest;
@@ -23,17 +25,15 @@ import no.nav.tjeneste.virksomhet.dokumentproduksjon.v3.meldinger.ProduserDokume
 import no.nav.tjeneste.virksomhet.dokumentproduksjon.v3.meldinger.ProduserIkkeredigerbartDokumentRequest;
 import no.nav.vedtak.exception.IntegrasjonException;
 
-
+@ExtendWith(MockitoExtension.class)
 public class DokumentProduksjonConsumerTest {
 
     private DokumentproduksjonConsumer consumer;
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    @Mock
+    private DokumentproduksjonV3 mockWebservice;
 
-    private DokumentproduksjonV3 mockWebservice = mock(DokumentproduksjonV3.class);
-
-    @Before
+    @BeforeEach
     public void setUp() {
         consumer = new DokumentproduksjonConsumerImpl(mockWebservice);
     }
@@ -42,40 +42,28 @@ public class DokumentProduksjonConsumerTest {
     public void skalKasteTekniskfeilNårWebserviceSenderSoapFault_ikkeRedigerbart() throws Exception {
         when(mockWebservice.produserIkkeredigerbartDokument(any(ProduserIkkeredigerbartDokumentRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.produserIkkeredigerbartDokument(mock(ProduserIkkeredigerbartDokumentRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.produserIkkeredigerbartDokument(mock(ProduserIkkeredigerbartDokumentRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilNårWebserviceSenderSoapFault_dokumentUtkast() throws Exception {
         when(mockWebservice.produserDokumentutkast(any(ProduserDokumentutkastRequest.class))).thenThrow(opprettSOAPFaultException("feil"));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.produserDokumentutkast(mock(ProduserDokumentutkastRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.produserDokumentutkast(mock(ProduserDokumentutkastRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilVedSoapFault_ferdigstillForsendelse() throws Exception {
         doThrow(opprettSOAPFaultException("feil")).when(mockWebservice).ferdigstillForsendelse(any(FerdigstillForsendelseRequest.class));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.ferdigstillForsendelse(mock(FerdigstillForsendelseRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.ferdigstillForsendelse(mock(FerdigstillForsendelseRequest.class)));
     }
 
     @Test
     public void skalKasteTekniskfeilVedSoapFault_knyttVedleggTilForsendelse() throws Exception {
         doThrow(opprettSOAPFaultException("feil")).when(mockWebservice).knyttVedleggTilForsendelse(any(KnyttVedleggTilForsendelseRequest.class));
 
-        expectedException.expect(IntegrasjonException.class);
-        expectedException.expectMessage("FP-942048");
-
-        consumer.knyttVedleggTilForsendelse(mock(KnyttVedleggTilForsendelseRequest.class));
+        assertThrows(IntegrasjonException.class, () -> consumer.knyttVedleggTilForsendelse(mock(KnyttVedleggTilForsendelseRequest.class)));
     }
 
     private SOAPFaultException opprettSOAPFaultException(String faultString) throws SOAPException {

--- a/domenetjenester/brevbestiller/pom.xml
+++ b/domenetjenester/brevbestiller/pom.xml
@@ -33,15 +33,23 @@
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>prosesstask</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger.melding</groupId>
             <artifactId>fpsak</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
             <artifactId>tps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.vedtak.prosesstask</groupId>
+            <artifactId>prosesstask-legacy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.melding</groupId>
+            <artifactId>prosesstask</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
@@ -85,6 +93,11 @@
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
             <version>4.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20200518</version>
         </dependency>
 
         <!-- test -->

--- a/domenetjenester/brevbestiller/src/test/resources/logback-test.xml
+++ b/domenetjenester/brevbestiller/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/domenetjenester/fpsak/pom.xml
+++ b/domenetjenester/fpsak/pom.xml
@@ -24,23 +24,9 @@
         </dependency>
         <!-- Eksterne -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20200518</version>
         </dependency>
     </dependencies>
 

--- a/domenetjenester/hendelse/pom.xml
+++ b/domenetjenester/hendelse/pom.xml
@@ -22,21 +22,21 @@
             <groupId>no.nav.foreldrepenger.melding</groupId>
             <artifactId>brevbestiller</artifactId>
         </dependency>
-
-        <!-- NAV -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.vedtak.prosesstask</groupId>
+            <artifactId>prosesstask-legacy</artifactId>
+        </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
             <artifactId>prosesstask</artifactId>
         </dependency>
 
+        <!-- NAV -->
+
         <!-- Eksterne -->
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/domenetjenester/organisasjon/pom.xml
+++ b/domenetjenester/organisasjon/pom.xml
@@ -18,10 +18,10 @@
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>ereg-klient</artifactId>
         </dependency>
-        <!-- test -->
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>dokumenthistorikk</artifactId>
+            <artifactId>domene</artifactId>
         </dependency>
+        <!-- test -->
     </dependencies>
 </project>

--- a/domenetjenester/poststed/pom.xml
+++ b/domenetjenester/poststed/pom.xml
@@ -22,7 +22,19 @@
         <!-- test -->
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>dokumenthistorikk</artifactId>
+            <artifactId>domene</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.vedtak.prosesstask</groupId>
+            <artifactId>prosesstask-legacy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.melding</groupId>
+            <artifactId>prosesstask</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/domenetjenester/tps/pom.xml
+++ b/domenetjenester/tps/pom.xml
@@ -22,6 +22,12 @@
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>aktoer-klient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>

--- a/integrasjon/dokdist-klient/pom.xml
+++ b/integrasjon/dokdist-klient/pom.xml
@@ -24,23 +24,9 @@
 
         <!-- Eksterne -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20200518</version>
         </dependency>
 
         <!-- Test -->

--- a/integrasjon/dokgen-klient/pom.xml
+++ b/integrasjon/dokgen-klient/pom.xml
@@ -24,23 +24,9 @@
 
         <!-- Eksterne -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20200518</version>
         </dependency>
 
         <!-- Test -->

--- a/integrasjon/journal-klient/pom.xml
+++ b/integrasjon/journal-klient/pom.xml
@@ -24,23 +24,9 @@
 
         <!-- Eksterne -->
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20200518</version>
         </dependency>
 
         <!-- Test -->

--- a/kafkatjenester/dokumenthendelse/pom.xml
+++ b/kafkatjenester/dokumenthendelse/pom.xml
@@ -41,23 +41,9 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/kafkatjenester/dokumenthistorikk/pom.xml
+++ b/kafkatjenester/dokumenthistorikk/pom.xml
@@ -27,45 +27,16 @@
             <artifactId>domene</artifactId>
         </dependency>
         <dependency>
+            <groupId>no.nav.vedtak.prosesstask</groupId>
+            <artifactId>prosesstask-legacy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
             <artifactId>prosesstask</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.felles</groupId>
             <artifactId>felles-testutilities</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>migreringer</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>test-sikkerhet</artifactId>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kafkatjenester/dokumenthistorikk/src/test/java/kafkatjenester/historikk/DokumentHistorikkTjenesteTest.java
+++ b/kafkatjenester/dokumenthistorikk/src/test/java/kafkatjenester/historikk/DokumentHistorikkTjenesteTest.java
@@ -1,23 +1,18 @@
 package kafkatjenester.historikk;
 
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.foreldrepenger.melding.dbstoette.UnittestRepositoryRule;
-import no.nav.foreldrepenger.melding.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.melding.hendelser.DokumentHendelse;
-import no.nav.foreldrepenger.melding.hendelser.HendelseRepository;
 import no.nav.foreldrepenger.melding.historikk.DokumentHistorikkinnslag;
 import no.nav.foreldrepenger.melding.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.melding.historikk.HistorikkinnslagType;
@@ -26,36 +21,26 @@ import no.nav.foreldrepenger.melding.kafkatjenester.historikk.DokumentHistorikki
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.DokumentMalType;
 import no.nav.foreldrepenger.melding.typer.JournalpostId;
 
+@ExtendWith(MockitoExtension.class)
 public class DokumentHistorikkTjenesteTest {
 
-    @Rule
-    public final UnittestRepositoryRule repositoryRule = new UnittestRepositoryRule();
-    @Rule
-    public MockitoRule mockitoRule = MockitoJUnit.rule().silent();
     private DokumentHistorikkTjeneste historikkTjeneste;
     @Spy
     private DokumentHistorikkinnslagProducer historikkMeldingProducer;
-    private HendelseRepository hendelseRepository;
 
-    @Before
+    @BeforeEach
     public void setup() {
-        hendelseRepository = new HendelseRepository(repositoryRule.getEntityManager());
         historikkTjeneste = new DokumentHistorikkTjeneste(historikkMeldingProducer);
-        doAnswer((i) -> null).when(historikkMeldingProducer).sendJson(Mockito.any());
+        lenient().doNothing().when(historikkMeldingProducer).sendJson(Mockito.any());
     }
 
     @Test
     public void publiserHistorikk() {
-        DokumentHendelse hendelse = DokumentHendelse.builder()
-                .medBehandlingUuid(UUID.randomUUID())
-                .medBestillingUuid(UUID.randomUUID())
-                .medYtelseType(FagsakYtelseType.FORELDREPENGER)
-                .build();
-        hendelseRepository.lagre(hendelse);
+
         DokumentHistorikkinnslag historikk = DokumentHistorikkinnslag.builder()
                 .medBehandlingUuid(UUID.randomUUID())
                 .medHistorikkUuid(UUID.randomUUID())
-                .medHendelseId(hendelse.getId())
+                .medHendelseId(1L)
                 .medDokumentMalType(DokumentMalType.UENDRETUTFALL_DOK)
                 .medJournalpostId(new JournalpostId("123"))
                 .medHistorikkAktør(HistorikkAktør.SAKSBEHANDLER)

--- a/kafkatjenester/dokumenthistorikk/src/test/resources/logback-test.xml
+++ b/kafkatjenester/dokumenthistorikk/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/kafkatjenester/kafkautil/pom.xml
+++ b/kafkatjenester/kafkautil/pom.xml
@@ -13,25 +13,29 @@
     <artifactId>kafkautil</artifactId>
 
     <dependencies>
-
         <dependency>
-            <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
-            <artifactId>felles-integrasjon-rest-klient</artifactId>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+
+        <!-- for å sette opp default ObjectMapper korrekt -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
     </dependencies>
+
 </project>

--- a/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_59__fjerne_kodelister.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/1.0/V1.1_59__fjerne_kodelister.sql
@@ -1,0 +1,10 @@
+drop table dokument_mal_type;
+drop table konfig_verdi;
+drop table konfig_verdi_kode;
+drop table kodeliste_relasjon;
+drop table kodeliste;
+drop table kodeverk;
+
+drop sequence seq_kodeliste;
+drop sequence seq_kodeliste_relasjon;
+drop sequence seq_konfig_verdi;

--- a/migreringer/src/test/resources/logback-test.xml
+++ b/migreringer/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- felles artifakter -->
-        <felles.version>2.3.0-20200921124341-8611713</felles.version>
-        <prosesstask.version>2.4.4-20200918181003-4bc2a52</prosesstask.version>
+        <felles.version>2.4.0-20201030150500-a194147</felles.version>
+        <prosesstask.version>2.4.4-20201029071156-ebb43cc</prosesstask.version>
         <kontrakter.version>5.1-20200401094249-8828af7</kontrakter.version>
 
         <!-- Eksterne -->
@@ -42,6 +42,8 @@
         <swagger-ui.version>3.35.2</swagger-ui.version>
         <kafka.version>2.6.0</kafka.version>
         <cxf.version>3.3.6</cxf.version>
+        <jupiter.version>5.7.0</jupiter.version>
+        <resteasy.version>4.5.8.Final</resteasy.version>
     </properties>
 
     <prerequisites>
@@ -115,6 +117,11 @@
                 <groupId>no.nav.foreldrepenger.melding</groupId>
                 <artifactId>migreringer</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.vedtak.prosesstask</groupId>
+                <artifactId>prosesstask-legacy</artifactId>
+                <version>${prosesstask.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.melding</groupId>
@@ -258,6 +265,55 @@
                 <version>3.3.4</version>
                 <classifier>jaxws</classifier>
             </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-servlet-initializer</artifactId>
+                <version>${resteasy.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.servlet</groupId>
+                        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-bom</artifactId>
+                <version>${resteasy.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-core</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-cdi</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxb-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jackson2-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-validator-provider</artifactId>
+                <version>${resteasy.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
@@ -269,11 +325,6 @@
                 <version>9.0</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-validator-provider</artifactId>
-                <version>3.13.2.Final</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.weld.module</groupId>
                 <artifactId>weld-web</artifactId>
                 <version>3.1.5.Final</version>
@@ -282,6 +333,12 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>3.0.1-b12</version>
+            </dependency>
+            <dependency>
+                <!-- velger en transitiv avhengighet - felles ikke enig med seg selv -->
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>1.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
@@ -321,6 +378,11 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${jupiter.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>

--- a/prosesstask/pom.xml
+++ b/prosesstask/pom.xml
@@ -13,6 +13,7 @@
     <name>FP-FORMIDLING :: Prosesstask</name>
     <packaging>jar</packaging>
 
+
     <dependencies>
         <dependency>
             <!-- Trengs for implementasjon av TaskManager -->
@@ -34,6 +35,10 @@
             <artifactId>felles-feil</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
             <groupId>no.nav.vedtak.prosesstask</groupId>
             <artifactId>prosesstask-legacy</artifactId>
         </dependency>
@@ -48,51 +53,8 @@
 
         <!-- REST felles -->
         <dependency>
-            <!-- Trengs for REST grensesnitt -->
             <groupId>no.nav.foreldrepenger.felles.sikkerhet</groupId>
             <artifactId>felles-sikkerhet</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Trengs for REST grensesnitt -->
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Trengs for REST grensesnitt -->
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Trengs for REST grensesnitt -->
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
-                    <groupId>org.jboss.spec.javax.xml.bind</groupId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Trengs for REST grensesnitt -->
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-validator-provider</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Trengs for REST grensesnitt -->
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-cdi</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/prosesstask/src/test/resources/logback-test.xml
+++ b/prosesstask/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,13 +17,5 @@
         <module>webapp</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-rt-transports-http-jetty</artifactId>
-                <version>3.3.7</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+
 </project>

--- a/web/webapp/pom.xml
+++ b/web/webapp/pom.xml
@@ -16,6 +16,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http-jetty</artifactId>
+                <version>${cxf.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>swagger-ui</artifactId>
                 <version>${swagger-ui.version}</version>
@@ -39,6 +44,26 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-servlet-initializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-validator-provider</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.melding</groupId>
@@ -72,19 +97,15 @@
             <version>3.1.0</version>
         </dependency>
         <!-- Foreldrepengeprosjektet -->
-        <dependency>
-            <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
-            <artifactId>felles-integrasjon-rest</artifactId>
-        </dependency>
 
         <!-- NAV -->
         <dependency>
-            <groupId>no.nav.foreldrepenger.melding</groupId>
-            <artifactId>prosesstask</artifactId>
-        </dependency>
-        <dependency>
             <groupId>no.nav.vedtak.prosesstask</groupId>
             <artifactId>prosesstask-legacy</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.melding</groupId>
+            <artifactId>prosesstask</artifactId>
         </dependency>
         <dependency>
             <groupId>no.nav.vedtak.prosesstask</groupId>
@@ -148,18 +169,6 @@
         </dependency>
 
         <!-- Server -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-plus</artifactId>

--- a/web/webapp/src/test/resources/logback-test.xml
+++ b/web/webapp/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%-5level] [%thread] %logger{5} - [%X{consumerId}, %X{callId}, %X{userId}] - %m%n</pattern>
+            <!-- pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern -->
+        </encoder>
+    </appender>
+
+    <logger name="no.nav" level="${log.level.no.nav:-INFO}" />
+	
+    <logger name="org.hibernate.SQL" level="${org.hibernate.SQL:-WARN}" />
+    <logger name="com.zaxxer.hikari" level="${org.zaxxer.hikari:-WARN}" />
+    <logger name="org.hibernate.type" level="${org.hibernate.type:-WARN}" />
+    <logger name="org.hibernate" level="${org.hibernate:-WARN}" />
+    <logger name="ch.qos.logback" level="${ch.qos.logback:-WARN}" />
+    <logger name="org.flywaydb" level="${org.flywaydb:-INFO}" />
+    
+    <logger name="org.apache" level="${org.apache:-ERROR}" />
+    
+    <logger name="org.jboss.weld" level="${org.jboss.weld:-WARN}" />
+    <logger name="org.jboss.resteasy" level="${org.jboss.resteasy:-WARN}" />
+    
+    <logger name="org.eclipse.jetty" level="${org.eclipse.jetty:-WARN}" />
+
+    <logger name="no.nav.modig" level="${log.level.no.nav.modig:-WARN}" />
+    <!-- denne logger passord på INFO nivå!-->
+    <logger name="no.nav.modig.core.test.PropertySetter" level="${log.level.no.nav.modig.core.test.PropertySetter:-WARN}" />
+
+    <root level="${log.level.root:-WARN}">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Den forrige må prodsettes før denne.
Har oppgradert til felles 2.4 og kjørt gjennom med maven-enforcer så det er litt endringer i poms.
