### PR TITLE
TFP-3884: Rettet så ny mal for varsel om revurdering hensyntas på all…

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokumentBehandlingTjenesteImpl.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokumentBehandlingTjenesteImpl.java
@@ -71,9 +71,11 @@ public class DokumentBehandlingTjenesteImpl implements DokumentBehandlingTjenest
             fjernes.add(DokumentMalType.FORLENGET_DOK);
             fjernes.add(DokumentMalType.FORLENGET_MEDL_DOK);
             fjernes.add(DokumentMalType.REVURDERING_DOK);
+            fjernes.add(DokumentMalType.VARSEL_OM_REVURDERING);
         } else if (behandling.erKlage()) {
             fjernes.add(DokumentMalType.FORLENGET_MEDL_DOK);
             fjernes.add(DokumentMalType.REVURDERING_DOK);
+            fjernes.add(DokumentMalType.VARSEL_OM_REVURDERING);
         } else if (behandling.erRevurdering()) {
             if (!automatiskOpprettet) {
                 fjernes.add(DokumentMalType.FORLENGET_DOK);
@@ -81,6 +83,7 @@ public class DokumentBehandlingTjenesteImpl implements DokumentBehandlingTjenest
             }
         } else {
             fjernes.add(DokumentMalType.REVURDERING_DOK);
+            fjernes.add(DokumentMalType.VARSEL_OM_REVURDERING);
         }
         return fjernes;
     }

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokumentMalUtleder.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokumentMalUtleder.java
@@ -151,7 +151,7 @@ class DokumentMalUtleder {
     private boolean harSendtVarselOmRevurdering(Behandling behandling) {
         return historikkRepository.hentInnslagForBehandling(behandling.getUuid())
                 .stream().map(DokumentHistorikkinnslag::getDokumentMalType)
-                .anyMatch(DokumentMalType.REVURDERING_DOK::equals)
+                .anyMatch(d -> DokumentMalType.REVURDERING_DOK.equals(d) || DokumentMalType.VARSEL_OM_REVURDERING.equals(d))
                 || Boolean.TRUE.equals(behandlingRestKlient.harSendtVarselOmRevurdering(behandling.getResourceLinker()).orElse(false));
     }
 


### PR DESCRIPTION
…e steder der den gamle brukt, slik at for eksempel ikke malen blir tilgjengelig for utsendelse på førstegangsbehandlinger.