### PR TITLE
TFP-4101 Lanserer infobrev til annen forelder

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenLanseringTjeneste.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenLanseringTjeneste.java
@@ -14,7 +14,8 @@ public class DokgenLanseringTjeneste {
             DokumentMalType.AVSLAG_ENGANGSSTØNAD,
             DokumentMalType.IKKE_SØKT,
             DokumentMalType.VARSEL_OM_REVURDERING,
-            DokumentMalType.INGEN_ENDRING);
+            DokumentMalType.INGEN_ENDRING,
+            DokumentMalType.INFOBREV_TIL_ANNEN_FORELDER);
     private static final Set<DokumentMalType> DOKGEN_MALER_DEV = Set.of(
             DokumentMalType.INNVILGELSE_ENGANGSSTØNAD,
             DokumentMalType.AVSLAG_ENGANGSSTØNAD,


### PR DESCRIPTION
Når det gjelder fjerner av bestemSaksnummer for Infobrev gammel variant så tenker jeg vi avventer det til vi har lansert, altså ikke i samme PR