### PR TITLE
TFP-4375: Øker header size i Jetty fra default 8192 til 32768 (fire g…

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenBrevproduksjonTjeneste.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenBrevproduksjonTjeneste.java
@@ -146,7 +146,7 @@ public class DokgenBrevproduksjonTjeneste implements BrevproduksjonTjeneste {
                 Element brevXmlElement = DokumentXmlDataMapper.mapTilBrevXml(DokumentMalType.INNVILGELSE_FORELDREPENGER_DOK, dokumentFelles, dokumentHendelse, behandling, saksnummer);
                 dokumentFelles.setAlternativeBrevData(elementTilString(brevXmlElement));
             } catch (Exception e) {
-                LOGGER.info("Feilet i å lage Dokprod-versjonen av innvilgelse foreldrepenger for bestilling {} og behandling {}", dokumentHendelse.getBestillingUuid(), dokumentHendelse.getBehandlingUuid());
+                LOGGER.info("Feilet i å lage Dokprod-versjonen av innvilgelse foreldrepenger for bestilling {} og behandling {}", dokumentHendelse.getBestillingUuid(), dokumentHendelse.getBehandlingUuid(), e);
             }
         }
     }

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokprodBrevproduksjonTjeneste.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokprodBrevproduksjonTjeneste.java
@@ -152,7 +152,7 @@ public class DokprodBrevproduksjonTjeneste implements BrevproduksjonTjeneste {
                 dokumentdata.getFelles().anonymiser();
                 dokumentFelles.setAlternativeBrevData(DefaultJsonMapper.toJson(dokumentdata));
             } catch (Exception e) {
-                LOGGER.info("Feilet i å lage Dokgen-versjonen av innvilgelse foreldrepenger for bestilling {} og behandling {}", dokumentHendelse.getBestillingUuid(), dokumentHendelse.getBehandlingUuid());
+                LOGGER.info("Feilet i å lage Dokgen-versjonen av innvilgelse foreldrepenger for bestilling {} og behandling {}", dokumentHendelse.getBestillingUuid(), dokumentHendelse.getBehandlingUuid(), e);
             }
         }
     }

--- a/web/webapp/src/main/java/no/nav/foreldrepenger/melding/web/server/jetty/AbstractJettyServer.java
+++ b/web/webapp/src/main/java/no/nav/foreldrepenger/melding/web/server/jetty/AbstractJettyServer.java
@@ -120,6 +120,9 @@ abstract class AbstractJettyServer {
         // Add support for X-Forwarded headers
         httpConfig.addCustomizer(new org.eclipse.jetty.server.ForwardedRequestCustomizer());
 
+        // Gjør det mulig å ta imot større argumenter igjennom REST (trengs for dokgen-json-til-pdf i forvaltningsgrensesnittet)
+        httpConfig.setRequestHeaderSize(32768);
+
         return httpConfig;
     }
 


### PR DESCRIPTION
…anger så mye), slik at det blir mulig å sende større JSON payloads til dokgen-json-til-pdf tjenesten. Logger med stack-trace hvis alternativt brev feiler, slik at det er mulig å se hvor det feilet.