### PR TITLE
TFP-2716: Logikken som merger perioder for innvilgelse FP må ta med i…

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapper.java
@@ -307,6 +307,7 @@ public final class UtbetalingsperiodeMapper {
             Optional<BeregningsgrunnlagPrStatusOgAndel> beregningsgrunnlagAndel, BeregningsgrunnlagPeriode beregningsgrunnlagPeriode) {
         var arbeidsforhold = Arbeidsforhold.ny()
                 .medArbeidsgiverNavn((beregningsresultatAndel.getArbeidsgiver().map(Arbeidsgiver::navn).orElse("Andel")));
+        arbeidsforhold.medAktivitetDagsats(beregningsresultatAndel.getDagsats());
         if (uttakAktivitet.isPresent()) {
             arbeidsforhold.medProsentArbeid(Prosent.of(uttakAktivitet.get().getArbeidsprosent()));
             arbeidsforhold.medUtbetalingsgrad(Prosent.of(uttakAktivitet.get().getUtbetalingsprosent()));

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMergerFelles.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMergerFelles.java
@@ -68,7 +68,7 @@ public final class UtbetalingsperiodeMergerFelles {
         return periodeEn.getAnnenAktivitetsliste().size() == periodeTo.getAnnenAktivitetsliste().size();
     }
 
-    private static boolean likArbeidsforholdListe(Utbetalingsperiode periodeEn, Utbetalingsperiode periodeTo) {
+    private static boolean harLikeMangeArbeidsforhold(Utbetalingsperiode periodeEn, Utbetalingsperiode periodeTo) {
         if (periodeEn.getArbeidsforholdsliste() == null && periodeTo.getArbeidsforholdsliste() == null) {
             return true;
         }
@@ -93,7 +93,7 @@ public final class UtbetalingsperiodeMergerFelles {
     }
 
     private static boolean likeArbeidsforhold(Utbetalingsperiode periodeEn, Utbetalingsperiode periodeTo) {
-        boolean alleMatcher = likArbeidsforholdListe(periodeEn, periodeTo);
+        boolean alleMatcher = harLikeMangeArbeidsforhold(periodeEn, periodeTo);
         if (!alleMatcher) {
             return false;
         }
@@ -137,8 +137,10 @@ public final class UtbetalingsperiodeMergerFelles {
     }
 
     private static boolean likArbeidsforholdType(Arbeidsforhold arb, Arbeidsforhold arb2) {
-        return  Objects.equals(arb.getNaturalytelseEndringDato(), arb2.getNaturalytelseEndringDato()) &&
-                Objects.equals(arb.getNaturalytelseEndringType(), arb2.getNaturalytelseEndringType()) &&
-                Objects.equals(arb.getNaturalytelseNyDagsats(), arb2.getNaturalytelseNyDagsats());
+        return Objects.equals(arb.getArbeidsgiverNavn(), arb2.getArbeidsgiverNavn()) &&
+               Objects.equals(arb.getAktivitetDagsats(), arb2.getAktivitetDagsats()) &&
+               Objects.equals(arb.getNaturalytelseEndringDato(), arb2.getNaturalytelseEndringDato()) &&
+               Objects.equals(arb.getNaturalytelseEndringType(), arb2.getNaturalytelseEndringType()) &&
+               Objects.equals(arb.getNaturalytelseNyDagsats(), arb2.getNaturalytelseNyDagsats());
     }
 }

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/sammenslåperioder/PeriodeMergerVerktøy.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/sammenslåperioder/PeriodeMergerVerktøy.java
@@ -108,7 +108,7 @@ public class PeriodeMergerVerktøy {
         return periodeEn.getAnnenAktivitetListe().getAnnenAktivitet().size() == periodeTo.getAnnenAktivitetListe().getAnnenAktivitet().size();
     }
 
-    private static boolean likArbeidsforholdListe(PeriodeType periodeEn, PeriodeType periodeTo) {
+    private static boolean harLikeMangeArbeidsforhold(PeriodeType periodeEn, PeriodeType periodeTo) {
         if (periodeEn.getArbeidsforholdListe() == null && periodeTo.getArbeidsforholdListe() == null) {
             return true;
         }
@@ -133,7 +133,7 @@ public class PeriodeMergerVerktøy {
     }
 
     static boolean likeArbeidsforhold(PeriodeType periodeEn, PeriodeType periodeTo) {
-        boolean alleMatcher = likArbeidsforholdListe(periodeEn, periodeTo);
+        boolean alleMatcher = harLikeMangeArbeidsforhold(periodeEn, periodeTo);
         if (!alleMatcher) {
             return false;
         }
@@ -182,7 +182,8 @@ public class PeriodeMergerVerktøy {
     }
 
     private static boolean likArbeidsforholdType(ArbeidsforholdType arb, ArbeidsforholdType arb2) {
-        return Objects.equals(arb.getAktivitetDagsats(), arb2.getAktivitetDagsats()) &&
+        return Objects.equals(arb.getArbeidsgiverNavn(), arb2.getArbeidsgiverNavn()) &&
+                Objects.equals(arb.getAktivitetDagsats(), arb2.getAktivitetDagsats()) &&
                 Objects.equals(arb.getNaturalytelseEndringDato(), arb2.getNaturalytelseEndringDato()) &&
                 Objects.equals(arb.getNaturalytelseEndringType(), arb2.getNaturalytelseEndringType()) &&
                 Objects.equals(arb.getNaturalytelseNyDagsats(), arb2.getNaturalytelseNyDagsats());

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMergerFellesTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMergerFellesTest.java
@@ -126,7 +126,6 @@ public class UtbetalingsperiodeMergerFellesTest {
     public void skal_finne_like_aktiviteter_kompleks_arbeidsforhold() {
         Utbetalingsperiode utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of()).build();
         Utbetalingsperiode utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of()).build();
-
         assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isTrue();
 
         utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medGradering(false).medNaturalytelseEndringDato("1").build())).build();
@@ -137,6 +136,22 @@ public class UtbetalingsperiodeMergerFellesTest {
 
         utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medGradering(false).medNaturalytelseEndringDato("2").medNaturalytelseNyDagsats(200L).build())).build();
         utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medGradering(false).medNaturalytelseEndringDato("2").build())).build();
+        assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isFalse();
+
+        utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medArbeidsgiverNavn("navn1").build())).build();
+        utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medArbeidsgiverNavn("navn1").build())).build();
+        assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isTrue();
+
+        utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medArbeidsgiverNavn("navn1").build())).build();
+        utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medArbeidsgiverNavn("navn2").build())).build();
+        assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isFalse();
+
+        utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medAktivitetDagsats(1).build())).build();
+        utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medAktivitetDagsats(1).build())).build();
+        assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isTrue();
+
+        utbetalingsperiode1 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medAktivitetDagsats(1).build())).build();
+        utbetalingsperiode2 = Utbetalingsperiode.ny().medArbeidsforhold(of(Arbeidsforhold.ny().medAktivitetDagsats(2).build())).build();
         assertThat(likeAktiviteter(utbetalingsperiode1, utbetalingsperiode2)).isFalse();
     }
 }

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/Arbeidsforhold.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/Arbeidsforhold.java
@@ -3,9 +3,13 @@ package no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class Arbeidsforhold {
+    @JsonIgnore
+    private int aktivitetDagsats;
+
     private String arbeidsgiverNavn;
     private boolean gradering;
     private Prosent prosentArbeid;
@@ -14,6 +18,14 @@ public class Arbeidsforhold {
     private NaturalytelseEndringType naturalytelseEndringType;
     private String naturalytelseEndringDato;
     private long naturalytelseNyDagsats;
+
+    public int getAktivitetDagsats() {
+        return aktivitetDagsats;
+    }
+
+    public String getArbeidsgiverNavn() {
+        return arbeidsgiverNavn;
+    }
 
     public boolean isGradering() {
         return gradering;
@@ -40,7 +52,8 @@ public class Arbeidsforhold {
         if (this == object) return true;
         if (object == null || getClass() != object.getClass()) return false;
         var that = (Arbeidsforhold) object;
-        return Objects.equals(arbeidsgiverNavn, that.arbeidsgiverNavn)
+        return Objects.equals(aktivitetDagsats, that.aktivitetDagsats)
+                && Objects.equals(arbeidsgiverNavn, that.arbeidsgiverNavn)
                 && Objects.equals(gradering, that.gradering)
                 && Objects.equals(prosentArbeid, that.prosentArbeid)
                 && Objects.equals(stillingsprosent, that.stillingsprosent)
@@ -52,8 +65,8 @@ public class Arbeidsforhold {
 
     @Override
     public int hashCode() {
-        return Objects.hash(arbeidsgiverNavn, gradering, prosentArbeid, stillingsprosent, utbetalingsgrad,
-                naturalytelseEndringType, naturalytelseEndringDato, naturalytelseNyDagsats);
+        return Objects.hash(aktivitetDagsats, arbeidsgiverNavn, gradering, prosentArbeid, stillingsprosent,
+                utbetalingsgrad, naturalytelseEndringType, naturalytelseEndringDato, naturalytelseNyDagsats);
     }
 
     public static Builder ny() {
@@ -65,6 +78,11 @@ public class Arbeidsforhold {
 
         private Builder() {
             this.kladd = new Arbeidsforhold();
+        }
+
+        public Builder medAktivitetDagsats(int aktivitetDagsats) {
+            this.kladd.aktivitetDagsats = aktivitetDagsats;
+            return this;
         }
 
         public Builder medArbeidsgiverNavn(String arbeidsgiverNavn) {


### PR DESCRIPTION
… vurderingen om det også er samme arbeidsgiverNavn, ellers vil perioder som tilfeldigvis har samme dagsats på to forskjellige arbeidsforhold kunne bli feilaktig slått sammen. Fiks for både Dokprod og Dokgen.