### PR TITLE
TFP-4374 Endret inkludereGradering til inkludereUtbetNårGradering da …

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/InnvilgelseForeldrepengerDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/InnvilgelseForeldrepengerDokumentdataMapper.java
@@ -56,8 +56,9 @@ import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.Støna
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.StønadskontoMapper.finnForeldrepengeperiodenUtvidetUkerHvisFinnes;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.StønadskontoMapper.finnPrematurDagerHvisFinnes;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereAvslag;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereGradering;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereInnvilget;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereNyeOpplysningerUtbet;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereUtbetNårGradering;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereUtbetaling;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallPerioder;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeFomHvisFinnes;
@@ -111,6 +112,7 @@ public class InnvilgelseForeldrepengerDokumentdataMapper implements Dokumentdata
                 beregningsresultatFP.getBeregningsresultatPerioder(), uttakResultatPerioder, beregningsgrunnlag.getBeregningsgrunnlagPerioder());
         String konsekvensForInnvilgetYtelse = mapKonsekvensForInnvilgetYtelse(behandling.getBehandlingsresultat().getKonsekvenserForYtelsen());
         boolean erInnvilgetRevurdering = erInnvilgetRevurdering(behandling);
+        long dagsats = finnDagsats(beregningsresultatFP);
 
         var dokumentdataBuilder = InnvilgelseForeldrepengerDokumentdata.ny()
                 .medFelles(fellesBuilder.build())
@@ -120,7 +122,7 @@ public class InnvilgelseForeldrepengerDokumentdataMapper implements Dokumentdata
                 .medKonsekvensForInnvilgetYtelse(konsekvensForInnvilgetYtelse)
                 .medSøknadsdato(formaterDatoNorsk(søknad.mottattDato()))
                 .medDekningsgrad(ytelseFordeling.dekningsgrad().getVerdi())
-                .medDagsats(finnDagsats(beregningsresultatFP))
+                .medDagsats(dagsats)
                 .medMånedsbeløp(finnMånedsbeløp(beregningsresultatFP))
                 .medForMyeUtbetalt(forMyeUtbetalt(utbetalingsperioder, behandling))
                 .medInntektMottattArbeidsgiver(erEndringMedEndretInntektsmelding(behandling))
@@ -156,9 +158,10 @@ public class InnvilgelseForeldrepengerDokumentdataMapper implements Dokumentdata
                         konsekvensForInnvilgetYtelse, erInnvilgetRevurdering))
 
                 .medInkludereUtbetaling(skalInkludereUtbetaling(behandling, utbetalingsperioder))
-                .medInkludereGradering(skalInkludereGradering(behandling, utbetalingsperioder))
+                .medInkludereUtbetNårGradering(skalInkludereUtbetNårGradering(behandling, utbetalingsperioder))
                 .medInkludereInnvilget(skalInkludereInnvilget(behandling, utbetalingsperioder, konsekvensForInnvilgetYtelse))
-                .medInkludereAvslag(skalInkludereAvslag(utbetalingsperioder, konsekvensForInnvilgetYtelse));
+                .medInkludereAvslag(skalInkludereAvslag(utbetalingsperioder, konsekvensForInnvilgetYtelse))
+                .medInkludereNyeOpplysningerUtbet(skalInkludereNyeOpplysningerUtbet(behandling, utbetalingsperioder, dagsats));
 
         mapFelterRelatertTilBeregningsgrunnlag(beregningsgrunnlag, dokumentdataBuilder);
 

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UndermalInkluderingMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UndermalInkluderingMapper.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import java.util.List;
-
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.BehandlingType;
 import no.nav.foreldrepenger.melding.behandling.KonsekvensForYtelsen;
@@ -10,18 +8,21 @@ import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Arbeid
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingResultatType;
 
+import java.util.List;
+
 /**
  * Klassen utleder hvorvidt for forskjellige blokker / undermaler i innvilgelse foreldrepenger brevet skal inkluderes:
  */
 public final class UndermalInkluderingMapper {
-    private static final List<String> UTBETALING_ÅRSAKER = List.of("2010" , "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2030", "2031", "2032", "2033", "2034", "2038");
+    private static final List<String> UTBETALING_ÅRSAKER = List.of("2010" , "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2030", "2031", "2032", "2033", "2034");
+    private static final List<String> GYLDIG_UTSETTELSE_ÅRSAKER = List.of("2010" , "2011", "2012", "2013", "2014");
 
     public static boolean skalInkludereUtbetaling(Behandling behandling, List<Utbetalingsperiode> utbetalingsperioder) {
         return behandling.getBehandlingsresultat().erInnvilget()
                 && (utbetalingsperioder.size() > 1 || harKunEnPeriodeUtenGraderingOgUtenGitteÅrsaker(utbetalingsperioder));
     }
 
-    public static boolean skalInkludereGradering(Behandling behandling, List<Utbetalingsperiode> utbetalingsperioder) {
+    public static boolean skalInkludereUtbetNårGradering(Behandling behandling, List<Utbetalingsperiode> utbetalingsperioder) {
         return behandling.getBehandlingsresultat().erInnvilget() && utbetalingsperioder.size() == 1 && periodeHarGitteÅrsakerEllerGradering(utbetalingsperioder.get(0));
     }
 
@@ -34,6 +35,10 @@ public final class UndermalInkluderingMapper {
 
     public static boolean skalInkludereAvslag(List<Utbetalingsperiode> utbetalingsperioder, String konsekvens) {
         return utbetalingsperioder.stream().anyMatch(periode -> !periode.isInnvilget()) && (!KonsekvensForYtelsen.ENDRING_I_BEREGNING.getKode().equals(konsekvens)) ;
+    }
+
+    public static boolean skalInkludereNyeOpplysningerUtbet(Behandling behandling, List<Utbetalingsperiode> utbetalingsperioder, long dagsats) {
+        return dagsats > 0 && behandling.getBehandlingsresultat().erInnvilget() && utbetalingsperioder.size() == 1 && periodeHarGyldigUtsettelseÅrsakerEllerGradering(utbetalingsperioder.get(0));
     }
 
     private static boolean harKunEnPeriodeUtenGraderingOgUtenGitteÅrsaker(List<Utbetalingsperiode> utbetalingsperioder) {
@@ -62,7 +67,16 @@ public final class UndermalInkluderingMapper {
 
     private static boolean periodeHarGitteÅrsakerEllerGradering(Utbetalingsperiode utbetalingsperiode) {
         return UTBETALING_ÅRSAKER.contains(utbetalingsperiode.getÅrsak())
-                || (utbetalingsperiode.getArbeidsforholdsliste().size() > 0 && utbetalingsperiode.getArbeidsforholdsliste().stream().anyMatch(Arbeidsforhold::isGradering))
+                || harGradering(utbetalingsperiode);
+    }
+
+    private static boolean periodeHarGyldigUtsettelseÅrsakerEllerGradering(Utbetalingsperiode utbetalingsperiode) {
+        return GYLDIG_UTSETTELSE_ÅRSAKER.contains(utbetalingsperiode.getÅrsak())
+                || harGradering(utbetalingsperiode);
+    }
+
+    private static boolean harGradering(Utbetalingsperiode utbetalingsperiode) {
+        return (utbetalingsperiode.getArbeidsforholdsliste().size() > 0 && utbetalingsperiode.getArbeidsforholdsliste().stream().anyMatch(Arbeidsforhold::isGradering))
                 || (utbetalingsperiode.getNæring() != null && utbetalingsperiode.getNæring().isGradering())
                 || (utbetalingsperiode.getAnnenAktivitetsliste().size() > 0 && utbetalingsperiode.getAnnenAktivitetsliste().stream().anyMatch(AnnenAktivitet::isGradering));
     }

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/InnvilgelseForeldrepengerDokumentdataMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/InnvilgelseForeldrepengerDokumentdataMapperTest.java
@@ -1,38 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static java.util.List.of;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnDagsats;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnMånedsbeløp;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
-import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
-import static no.nav.foreldrepenger.melding.typer.DatoIntervall.fraOgMedTilOgMed;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import no.nav.foreldrepenger.melding.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktStatus;
@@ -81,6 +48,38 @@ import no.nav.foreldrepenger.melding.uttak.kodeliste.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.melding.ytelsefordeling.OppgittRettighet;
 import no.nav.foreldrepenger.melding.ytelsefordeling.YtelseFordeling;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnDagsats;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnMånedsbeløp;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
+import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
+import static no.nav.foreldrepenger.melding.typer.DatoIntervall.fraOgMedTilOgMed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class InnvilgelseForeldrepengerDokumentdataMapperTest {
@@ -185,9 +184,10 @@ public class InnvilgelseForeldrepengerDokumentdataMapperTest {
         assertThat(dokumentdata.getLovhjemlerBeregning()).isEqualTo("§§ 14-7 og forvaltningsloven § 35");
 
         assertThat(dokumentdata.getInkludereUtbetaling()).isTrue();
-        assertThat(dokumentdata.getInkludereGradering()).isFalse();
+        assertThat(dokumentdata.getInkludereUtbetNårGradering()).isFalse();
         assertThat(dokumentdata.getInkludereInnvilget()).isTrue();
         assertThat(dokumentdata.getInkludereAvslag()).isTrue();
+        assertThat(dokumentdata.getInkludereNyeOpplysningerUtbet()).isFalse();
 
         assertThat(dokumentdata.getBeregningsgrunnlagregler()).hasSize(1);
         assertThat(dokumentdata.getBruttoBeregningsgrunnlag()).isEqualTo(BRUTTO_BERENINGSGRUNNLAG);

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UndermalInkluderingMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UndermalInkluderingMapperTest.java
@@ -1,14 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static java.util.List.of;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereAvslag;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereGradering;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereInnvilget;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereUtbetaling;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.Test;
-
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.BehandlingType;
 import no.nav.foreldrepenger.melding.behandling.Behandlingsresultat;
@@ -18,6 +9,15 @@ import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Arbeid
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Næring;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingResultatType;
+import org.junit.jupiter.api.Test;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereAvslag;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereInnvilget;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereNyeOpplysningerUtbet;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereUtbetNårGradering;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UndermalInkluderingMapper.skalInkludereUtbetaling;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UndermalInkluderingMapperTest {
 
@@ -153,7 +153,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("2010").build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode));
 
         // Assert
         assertThat(resultat).isTrue();
@@ -170,7 +170,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("1234").build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -187,7 +187,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("1234").medAnnenAktivitet(of(AnnenAktivitet.ny().medGradering(true).build())).build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode));
 
         // Assert
         assertThat(resultat).isTrue();
@@ -204,7 +204,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("1234").medAnnenAktivitet(of(AnnenAktivitet.ny().medGradering(false).build())).build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -222,7 +222,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode2 = Utbetalingsperiode.ny().medÅrsak("2011").build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode1, utbetalingsperiode2));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode1, utbetalingsperiode2));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -239,7 +239,7 @@ public class UndermalInkluderingMapperTest {
         Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("2010").build();
 
         // Act
-        boolean resultat = skalInkludereGradering(behandling, of(utbetalingsperiode));
+        boolean resultat = skalInkludereUtbetNårGradering(behandling, of(utbetalingsperiode));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -401,5 +401,54 @@ public class UndermalInkluderingMapperTest {
 
         // Assert
         assertThat(resultat).isTrue();
+    }
+
+    @Test
+    public void skal_inkludere_skalInkludereNyeOpplysningerUtbet_når_det_er_en_periode_med_gradering() {
+        Behandlingsresultat behandlingsresultat = Behandlingsresultat.builder()
+                .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
+                .build();
+        Behandling behandling = Behandling.builder().medBehandlingsresultat(behandlingsresultat).build();
+
+        Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("1234").medAnnenAktivitet(of(AnnenAktivitet.ny().medGradering(true).build())).build();
+
+        // Act
+        boolean resultat = skalInkludereNyeOpplysningerUtbet(behandling, of(utbetalingsperiode), 123);
+
+        // Assert
+        assertThat(resultat).isTrue();
+    }
+
+    @Test
+    public void skalInkludereNyeOpplysningerUtbet_når_en_periode_og_gyldig_utstettelse_årsak() {
+        Behandlingsresultat behandlingsresultat = Behandlingsresultat.builder()
+                .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
+                .build();
+        Behandling behandling = Behandling.builder().medBehandlingsresultat(behandlingsresultat).build();
+
+        Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("2010").medInnvilget(true).build();
+
+        // Act
+        boolean resultat = skalInkludereNyeOpplysningerUtbet(behandling, of(utbetalingsperiode), 123);
+
+        // Assert
+        assertThat(resultat).isTrue();
+    }
+
+    @Test
+    public void skal_ikke_inkludereNyeOpplysningerUtbet_når_flere_perioder() {
+        Behandlingsresultat behandlingsresultat = Behandlingsresultat.builder()
+                .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
+                .build();
+        Behandling behandling = Behandling.builder().medBehandlingsresultat(behandlingsresultat).build();
+
+        Utbetalingsperiode utbetalingsperiode = Utbetalingsperiode.ny().medÅrsak("2010").medInnvilget(true).build();
+        Utbetalingsperiode utbetalingsperiode2 = Utbetalingsperiode.ny().medÅrsak("2011").medInnvilget(true).build();
+
+        // Act
+        boolean resultat = skalInkludereNyeOpplysningerUtbet(behandling, of(utbetalingsperiode, utbetalingsperiode2), 123);
+
+        // Assert
+        assertThat(resultat).isFalse();
     }
 }

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/InnvilgelseForeldrepengerDokumentdata.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/InnvilgelseForeldrepengerDokumentdata.java
@@ -1,13 +1,12 @@
 package no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.Dokumentdata;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.FellesDokumentdata;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.Dokumentdata;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.FellesDokumentdata;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
@@ -60,9 +59,10 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
     private String lovhjemlerBeregning;
 
     private boolean inkludereUtbetaling;
-    private boolean inkludereGradering;
+    private boolean inkludereUtbetNårGradering;
     private boolean inkludereInnvilget;
     private boolean inkludereAvslag;
+    private boolean inkludereNyeOpplysningerUtbet;
 
     public String getBehandlingType() {
         return behandlingType;
@@ -236,8 +236,8 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
         return inkludereUtbetaling;
     }
 
-    public boolean getInkludereGradering() {
-        return inkludereGradering;
+    public boolean getInkludereUtbetNårGradering() {
+        return inkludereUtbetNårGradering;
     }
 
     public boolean getInkludereInnvilget() {
@@ -247,6 +247,8 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
     public boolean getInkludereAvslag() {
         return inkludereAvslag;
     }
+
+    public boolean getInkludereNyeOpplysningerUtbet() { return inkludereNyeOpplysningerUtbet; }
 
     @Override
     public boolean equals(Object object) {
@@ -298,9 +300,10 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
                 && Objects.equals(lovhjemlerUttak, that.lovhjemlerUttak)
                 && Objects.equals(lovhjemlerBeregning, that.lovhjemlerBeregning)
                 && Objects.equals(inkludereUtbetaling, that.inkludereUtbetaling)
-                && Objects.equals(inkludereGradering, that.inkludereGradering)
+                && Objects.equals(inkludereUtbetNårGradering, that.inkludereUtbetNårGradering)
                 && Objects.equals(inkludereInnvilget, that.inkludereInnvilget)
-                && Objects.equals(inkludereAvslag, that.inkludereAvslag);
+                && Objects.equals(inkludereAvslag, that.inkludereAvslag)
+                && Objects.equals(inkludereNyeOpplysningerUtbet, that.inkludereNyeOpplysningerUtbet);
     }
 
     @Override
@@ -312,7 +315,8 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
                 antallPerioder, harInnvilgedePerioder, antallArbeidsgivere, dagerTaptFørTermin, disponibleDager, disponibleFellesDager,
                 sisteDagAvSistePeriode, stønadsperiodeFom, stønadsperiodeTom, foreldrepengeperiodenUtvidetUker, antallBarn, prematurDager,
                 perioder, bruttoBeregningsgrunnlag, harBruktBruttoBeregningsgrunnlag, beregningsgrunnlagregler, klagefristUker,
-                lovhjemlerUttak, lovhjemlerBeregning, inkludereUtbetaling, inkludereGradering, inkludereInnvilget, inkludereAvslag);
+                lovhjemlerUttak, lovhjemlerBeregning, inkludereUtbetaling, inkludereUtbetNårGradering, inkludereInnvilget, inkludereAvslag,
+                inkludereNyeOpplysningerUtbet);
     }
 
     public static Builder ny() {
@@ -551,8 +555,8 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
             return this;
         }
 
-        public Builder medInkludereGradering(boolean inkludereGradering) {
-            this.kladd.inkludereGradering = inkludereGradering;
+        public Builder medInkludereUtbetNårGradering(boolean inkludereUtbetNårGradering) {
+            this.kladd.inkludereUtbetNårGradering = inkludereUtbetNårGradering;
             return this;
         }
 
@@ -563,6 +567,11 @@ public class InnvilgelseForeldrepengerDokumentdata extends Dokumentdata {
 
         public Builder medInkludereAvslag(boolean inkludereAvslag) {
             this.kladd.inkludereAvslag = inkludereAvslag;
+            return this;
+        }
+
+        public Builder medInkludereNyeOpplysningerUtbet(boolean inkludereNyeOpplysningerUtbet) {
+            this.kladd.inkludereNyeOpplysningerUtbet = inkludereNyeOpplysningerUtbet;
             return this;
         }
 


### PR DESCRIPTION
…logikken for denne er at den skal inkludere utbetalingsundermal dersom kriterer slår til. Lagt til inkludereNyeOpplysningerUtbet for å håndtere at tekst knyttet til denne vises når kriterier er oppfylt. Fjernet 2038 fra UTBETALING_ÅRSAKER da denne ikke er implementert for innvilget foreldrepenger i dokprod