### PR TITLE
TFP-4501 Innvilget-foreldrepenger: manglet sjekk på ingenRefusjon.

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/BeregningsresultatMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/BeregningsresultatMapper.java
@@ -1,16 +1,16 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
 import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
 import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 
 public final class BeregningsresultatMapper {
 
@@ -35,7 +35,8 @@ public final class BeregningsresultatMapper {
     }
 
     public static boolean harIngenRefusjon(BeregningsresultatFP beregningsresultatFP) {
-        return harBrukerAndel(beregningsresultatFP) && !harArbeidsgiverAndel(beregningsresultatFP);
+        return (harBrukerAndel(beregningsresultatFP) && !harArbeidsgiverAndel(beregningsresultatFP)) ||
+                (!harBrukerAndel(beregningsresultatFP) && !harArbeidsgiverAndel(beregningsresultatFP));
     }
 
     public static boolean harDelvisRefusjon(BeregningsresultatFP beregningsresultatFP) {

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/BeregningsresultatMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/BeregningsresultatMapperTest.java
@@ -1,5 +1,15 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
+import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
+import no.nav.foreldrepenger.melding.typer.DatoIntervall;
+import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
 import static java.util.List.of;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnAntallArbeidsgivere;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.finnDagsats;
@@ -8,17 +18,6 @@ import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.Beregn
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.harFullRefusjon;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsresultatMapper.harIngenRefusjon;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.LocalDate;
-
-import org.junit.jupiter.api.Test;
-
-import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
-import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
-import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
-import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
-import no.nav.foreldrepenger.melding.typer.DatoIntervall;
-import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
 
 public class BeregningsresultatMapperTest {
 
@@ -165,6 +164,36 @@ public class BeregningsresultatMapperTest {
         assertThat(harIngenRefusjon(beregningsresultat)).isTrue();
     }
 
+    @Test
+    public void skal_finne_at_bruker_har_ingen_refusjon_når_ingen_er_mottakere() {
+        // Arrange
+        BeregningsresultatFP beregningsresultat = BeregningsresultatFP.ny()
+                .leggTilBeregningsresultatPerioder(of(
+                        BeregningsresultatPeriode.ny()
+                                .medPeriode(UBETYDELIG_PERIODE)
+                                .medBeregningsresultatAndel(of(
+                                        BeregningsresultatAndel.ny()
+                                                .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                                                .medArbeidsgiver(new Arbeidsgiver("Navn1", "Referanse1"))
+                                                .medBrukerErMottaker(false)
+                                                .build()
+                                ))
+                                .build(),
+                        BeregningsresultatPeriode.ny()
+                                .medPeriode(UBETYDELIG_PERIODE)
+                                .medBeregningsresultatAndel(of(
+                                        BeregningsresultatAndel.ny()
+                                                .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                                                .medArbeidsgiver(new Arbeidsgiver("Navn2", "Referanse2"))
+                                                .medArbeidsgiverErMottaker(false)
+                                                .build()
+                                ))
+                                .build()))
+                .build();
+
+        // Act + Assert
+        assertThat(harIngenRefusjon(beregningsresultat)).isTrue();
+    }
 
     @Test
     public void skal_finne_at_bruker_har_delvis_refusjon() {


### PR DESCRIPTION
Manglet håndtering av tilfellene hvor bruker har fått innvilget foreldrepenger, men utsetter fra start så ingen utbetaling og derav ingen refusjon.