### PR TITLE
TFP-4582 Innvilgese foreldrepenger brev rettelse

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
@@ -64,8 +64,8 @@ import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.Underm
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallAvslåttePerioder;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallInnvilgedePerioder;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallPerioder;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeFomHvisFinnes;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeTomHvisFinnes;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeFom;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeTom;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnesPeriodeMedIkkeOmsorg;
 import static no.nav.foreldrepenger.melding.datamapper.domene.BehandlingMapper.avklarFritekst;
 import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.opprettFellesBuilder;
@@ -149,8 +149,6 @@ public class ForeldrepengerInnvilgelseDokumentdataMapper implements Dokumentdata
                 .medDisponibleDager(finnDisponibleDager(saldoer, fagsak.getRelasjonsRolleType()))
                 .medDisponibleFellesDager(finnDisponibleFellesDager(saldoer))
                 .medSisteDagAvSistePeriode(formaterDatoNorsk(finnSisteDagAvSistePeriode(uttakResultatPerioder)))
-                .medStønadsperiodeFom(formaterDatoNorsk(finnStønadsperiodeFomHvisFinnes(utbetalingsperioder)))
-                .medStønadsperiodeTom(formaterDatoNorsk(finnStønadsperiodeTomHvisFinnes(utbetalingsperioder)))
                 .medForeldrepengeperiodenUtvidetUker(finnForeldrepengeperiodenUtvidetUkerHvisFinnes(saldoer))
                 .medAntallBarn(familieHendelse.getAntallBarn().intValue())
                 .medPrematurDager(finnPrematurDagerHvisFinnes(saldoer))
@@ -166,6 +164,10 @@ public class ForeldrepengerInnvilgelseDokumentdataMapper implements Dokumentdata
                 .medInkludereInnvilget(skalInkludereInnvilget(behandling, utbetalingsperioder, konsekvensForInnvilgetYtelse))
                 .medInkludereAvslag(skalInkludereAvslag(utbetalingsperioder, konsekvensForInnvilgetYtelse))
                 .medInkludereNyeOpplysningerUtbet(skalInkludereNyeOpplysningerUtbet(behandling, utbetalingsperioder, dagsats));
+
+        finnStønadsperiodeFom(utbetalingsperioder).ifPresent(dato-> dokumentdataBuilder.medStønadsperiodeFom(formaterDatoNorsk(dato)));
+        finnStønadsperiodeTom(utbetalingsperioder).ifPresent(dato-> dokumentdataBuilder.medStønadsperiodeTom(formaterDatoNorsk(dato)));
+
 
         mapFelterRelatertTilBeregningsgrunnlag(beregningsgrunnlag, dokumentdataBuilder);
 

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapper.java
@@ -1,20 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMerger.mergePerioder;
-import static no.nav.foreldrepenger.melding.datamapper.domene.sammenslåperioder.PeriodeBeregner.alleAktiviteterHarNullUtbetaling;
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
 import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
@@ -33,6 +18,21 @@ import no.nav.foreldrepenger.melding.uttak.UttakResultatPeriodeAktivitet;
 import no.nav.foreldrepenger.melding.uttak.UttakResultatPerioder;
 import no.nav.foreldrepenger.melding.uttak.kodeliste.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMerger.mergePerioder;
+import static no.nav.foreldrepenger.melding.datamapper.domene.sammenslåperioder.PeriodeBeregner.alleAktiviteterHarNullUtbetaling;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
 
 public final class UtbetalingsperiodeMapper {
 
@@ -75,18 +75,18 @@ public final class UtbetalingsperiodeMapper {
         return periodeliste;
     }
 
-    public static LocalDate finnStønadsperiodeFomHvisFinnes(List<Utbetalingsperiode> periodeListe) {
+    public static Optional<LocalDate> finnStønadsperiodeFom(List<Utbetalingsperiode> periodeListe) {
         return periodeListe.stream()
                 .filter(p -> Boolean.TRUE.equals(p.isInnvilget()))
                 .map(Utbetalingsperiode::getPeriodeFom)
-                .min(Comparator.comparing(LocalDate::toEpochDay)).orElse(null);
+                .min(Comparator.comparing(LocalDate::toEpochDay));
     }
 
-    public static LocalDate finnStønadsperiodeTomHvisFinnes(List<Utbetalingsperiode> periodeListe) {
+    public static Optional<LocalDate> finnStønadsperiodeTom(List<Utbetalingsperiode> periodeListe) {
         return periodeListe.stream()
                 .filter(p -> Boolean.TRUE.equals(p.isInnvilget()))
                 .map(Utbetalingsperiode::getPeriodeTom)
-                .max(Comparator.comparing(LocalDate::toEpochDay)).orElse(null);
+                .max(Comparator.comparing(LocalDate::toEpochDay));
     }
 
     public static int finnAntallPerioder(List<Utbetalingsperiode> utbetalingsperioder) {

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMapperTest.java
@@ -1,21 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static java.util.List.of;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallAvslåttePerioder;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallInnvilgedePerioder;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallPerioder;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeFomHvisFinnes;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeTomHvisFinnes;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnesPeriodeMedIkkeOmsorg;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
 import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
@@ -30,6 +14,22 @@ import no.nav.foreldrepenger.melding.uttak.UttakResultatPeriode;
 import no.nav.foreldrepenger.melding.uttak.UttakResultatPeriodeAktivitet;
 import no.nav.foreldrepenger.melding.uttak.UttakResultatPerioder;
 import no.nav.foreldrepenger.melding.uttak.kodeliste.PeriodeResultatÅrsak;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallAvslåttePerioder;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallInnvilgedePerioder;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnAntallPerioder;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeFom;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnStønadsperiodeTom;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.UtbetalingsperiodeMapper.finnesPeriodeMedIkkeOmsorg;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UtbetalingsperiodeMapperTest {
 
@@ -306,8 +306,8 @@ public class UtbetalingsperiodeMapperTest {
         leggtilPeriode(LocalDate.of(2019, 3, 1), LocalDate.of(2019, 3, 30), false, utbetalingsperioder);
 
         // Act + Assert
-        assertThat(finnStønadsperiodeFomHvisFinnes(utbetalingsperioder)).isEqualTo(førsteJanuarTjueAtten);
-        assertThat(finnStønadsperiodeTomHvisFinnes(utbetalingsperioder)).isEqualTo(trettiendeAprilTjueAtten);
+        assertThat(finnStønadsperiodeFom(utbetalingsperioder)).isEqualTo(Optional.of(førsteJanuarTjueAtten));
+        assertThat(finnStønadsperiodeTom(utbetalingsperioder)).isEqualTo(Optional.of(trettiendeAprilTjueAtten));
     }
 
     @Test


### PR DESCRIPTION
Endret slik at stønadsperiodefom og tom kun mappes om datoene finnes siden de i enkelte tilfeller ikke har verdi. Null ble ikke godtatt av json når verdien var satt til required i schema.