### PR TITLE
TFP-4569: Sender i stedet tom string til Fp-dokgen når lovhjemmel er …

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
@@ -1,44 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import no.nav.foreldrepenger.melding.aksjonspunkt.Aksjonspunkt;
-import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktStatus;
-import no.nav.foreldrepenger.melding.behandling.Behandling;
-import no.nav.foreldrepenger.melding.behandling.BehandlingType;
-import no.nav.foreldrepenger.melding.behandling.KonsekvensForYtelsen;
-import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
-import no.nav.foreldrepenger.melding.beregningsgrunnlag.Beregningsgrunnlag;
-import no.nav.foreldrepenger.melding.brevmapper.DokumentdataMapper;
-import no.nav.foreldrepenger.melding.datamapper.DomeneobjektProvider;
-import no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper;
-import no.nav.foreldrepenger.melding.datamapper.domene.UttakMapper;
-import no.nav.foreldrepenger.melding.datamapper.konfig.BrevParametere;
-import no.nav.foreldrepenger.melding.dokumentdata.DokumentFelles;
-import no.nav.foreldrepenger.melding.dokumentdata.DokumentMalTypeRef;
-import no.nav.foreldrepenger.melding.fagsak.FagsakBackend;
-import no.nav.foreldrepenger.melding.familiehendelse.FamilieHendelse;
-import no.nav.foreldrepenger.melding.hendelser.DokumentHendelse;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.BeregningsgrunnlagRegel;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.ForeldrepengerInnvilgelseDokumentdata;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.VurderingsKode;
-import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingÅrsakType;
-import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.DokumentMalTypeKode;
-import no.nav.foreldrepenger.melding.personopplysning.RelasjonsRolleType;
-import no.nav.foreldrepenger.melding.søknad.Søknad;
-import no.nav.foreldrepenger.melding.uttak.Saldoer;
-import no.nav.foreldrepenger.melding.uttak.UttakResultatPeriode;
-import no.nav.foreldrepenger.melding.uttak.UttakResultatPerioder;
-import no.nav.foreldrepenger.melding.ytelsefordeling.YtelseFordeling;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Stream;
-
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsgrunnlagMapper.finnBrutto;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsgrunnlagMapper.finnSeksG;
 import static no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp.BeregningsgrunnlagMapper.harBruktBruttoBeregningsgrunnlag;
@@ -71,6 +32,46 @@ import static no.nav.foreldrepenger.melding.datamapper.domene.BehandlingMapper.a
 import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.opprettFellesBuilder;
 import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
 import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.melding.aksjonspunkt.Aksjonspunkt;
+import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktStatus;
+import no.nav.foreldrepenger.melding.behandling.Behandling;
+import no.nav.foreldrepenger.melding.behandling.BehandlingType;
+import no.nav.foreldrepenger.melding.behandling.KonsekvensForYtelsen;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
+import no.nav.foreldrepenger.melding.beregningsgrunnlag.Beregningsgrunnlag;
+import no.nav.foreldrepenger.melding.brevmapper.DokumentdataMapper;
+import no.nav.foreldrepenger.melding.datamapper.DomeneobjektProvider;
+import no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper;
+import no.nav.foreldrepenger.melding.datamapper.domene.UttakMapper;
+import no.nav.foreldrepenger.melding.datamapper.konfig.BrevParametere;
+import no.nav.foreldrepenger.melding.dokumentdata.DokumentFelles;
+import no.nav.foreldrepenger.melding.dokumentdata.DokumentMalTypeRef;
+import no.nav.foreldrepenger.melding.fagsak.FagsakBackend;
+import no.nav.foreldrepenger.melding.familiehendelse.FamilieHendelse;
+import no.nav.foreldrepenger.melding.hendelser.DokumentHendelse;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.BeregningsgrunnlagRegel;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.ForeldrepengerInnvilgelseDokumentdata;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.VurderingsKode;
+import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingÅrsakType;
+import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.DokumentMalTypeKode;
+import no.nav.foreldrepenger.melding.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.melding.søknad.Søknad;
+import no.nav.foreldrepenger.melding.uttak.Saldoer;
+import no.nav.foreldrepenger.melding.uttak.UttakResultatPeriode;
+import no.nav.foreldrepenger.melding.uttak.UttakResultatPerioder;
+import no.nav.foreldrepenger.melding.ytelsefordeling.YtelseFordeling;
 
 @ApplicationScoped
 @DokumentMalTypeRef(DokumentMalTypeKode.FORELDREPENGER_INNVILGELSE)
@@ -156,7 +157,7 @@ public class ForeldrepengerInnvilgelseDokumentdataMapper implements Dokumentdata
                 .medKlagefristUker(brevParametere.getKlagefristUker())
                 .medLovhjemlerUttak(UttakMapper.mapLovhjemlerForUttak(uttakResultatPerioder, konsekvensForInnvilgetYtelse, erInnvilgetRevurdering))
                 .medLovhjemlerBeregning(FellesMapper.formaterLovhjemlerForBeregning(beregningsgrunnlag.getHjemmel().getNavn(),
-                        konsekvensForInnvilgetYtelse, erInnvilgetRevurdering, fagsak.getSaksnummer()))
+                        konsekvensForInnvilgetYtelse, erInnvilgetRevurdering, behandling))
 
                 .medInkludereUtbetaling(skalInkludereUtbetaling(behandling, utbetalingsperioder))
                 .medInkludereUtbetNårGradering(skalInkludereUtbetNårGradering(behandling, utbetalingsperioder))

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseForeldrepengerMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/brev/InnvilgelseForeldrepengerMapper.java
@@ -1,7 +1,7 @@
 package no.nav.foreldrepenger.melding.datamapper.brev;
 
 import static no.nav.foreldrepenger.melding.datamapper.domene.BehandlingMapper.avklarFritekst;
-import static no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper.formaterLovhjemlerForBeregningDokprod;
+import static no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper.formaterLovhjemlerForBeregning;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -164,7 +164,7 @@ public class InnvilgelseForeldrepengerMapper extends DokumentTypeMapper {
         boolean revurdering = BehandlingType.REVURDERING.equals(behandling.getBehandlingType());
         boolean innvilget = BehandlingResultatType.INNVILGET.equals(behandling.getBehandlingsresultat().getBehandlingResultatType());
         boolean innvilgetRevurdering = revurdering && innvilget;
-        lovhjemmelType.setBeregning(formaterLovhjemlerForBeregningDokprod(beregningsgrunnlag.getHjemmel().getNavn(), konsekvensForYtelsen, innvilgetRevurdering));
+        lovhjemmelType.setBeregning(formaterLovhjemlerForBeregning(beregningsgrunnlag.getHjemmel().getNavn(), konsekvensForYtelsen, innvilgetRevurdering, behandling));
         lovhjemmelType.setVurdering(UttakMapper.mapLovhjemlerForUttak(uttakResultatPerioder, konsekvensForYtelsen, innvilgetRevurdering));
         fagType.setLovhjemmel(lovhjemmelType);
     }

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/FellesMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/FellesMapper.java
@@ -7,34 +7,21 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.melding.beregningsgrunnlag.Hjemmel;
-import no.nav.foreldrepenger.melding.typer.Saksnummer;
 
 public class FellesMapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FellesMapper.class);
-    public static final String UDEFINERT = "UDEFINERT";
 
-    @Deprecated //Ivaretar eksisterende returverdi ved null for gamle brev - slettes med Dokprod-brevene
-    public static String formaterLovhjemlerForBeregningDokprod(String lovhjemmelBeregning, String konsekvensForYtelse, boolean innvilgetRevurdering) {
+    public static String formaterLovhjemlerForBeregning(String lovhjemmelBeregning, String konsekvensForYtelse, boolean innvilgetRevurdering, Behandling behandling) {
         if (lovhjemmelBeregning == null) {
-            return "";
-        }
-        return doFormaterLovhjemlerForBeregning(lovhjemmelBeregning, konsekvensForYtelse, innvilgetRevurdering);
-    }
-
-    public static String formaterLovhjemlerForBeregning(String lovhjemmelBeregning, String konsekvensForYtelse, boolean innvilgetRevurdering, Saksnummer saksnummer) {
-        if (lovhjemmelBeregning == null) {
-            return UDEFINERT;
+            lovhjemmelBeregning = "";
         } else if (Hjemmel.UDEFINERT.getNavn().equals(lovhjemmelBeregning)) {
-            LOGGER.warn(saksnummer.toString() + " har udefinert hjemmel. Fint om du melder dette på TFP-4569 så vi kan se hvor ofte det skjer.");
-            return UDEFINERT;
+            LOGGER.warn("Behandling " + behandling.getUuid() + " har udefinert hjemmel. Fint om du melder dette på TFP-4569 så vi kan se hvor ofte det skjer.");
+            lovhjemmelBeregning = "";
         }
-        return doFormaterLovhjemlerForBeregning(lovhjemmelBeregning, konsekvensForYtelse, innvilgetRevurdering);
-    }
-
-    private static String doFormaterLovhjemlerForBeregning(String lovhjemmelBeregning, String konsekvensForYtelse, boolean innvilgetRevurdering) {
         if (endringIBeregning(konsekvensForYtelse) || innvilgetRevurdering) {
             lovhjemmelBeregning += (" og forvaltningsloven § 35");
         }

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/svp/SvpUtledHjemmelForBeregning.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/domene/svp/SvpUtledHjemmelForBeregning.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.melding.datamapper.domene.svp;
 
-import static no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper.formaterLovhjemlerForBeregningDokprod;
+import static no.nav.foreldrepenger.melding.datamapper.domene.FellesMapper.formaterLovhjemlerForBeregning;
 
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.BehandlingType;
@@ -26,8 +26,7 @@ final class SvpUtledHjemmelForBeregning {
             hjemmel = hjemmel.replace("14-7", "14-4");
         }
 
-        return formaterLovhjemlerForBeregningDokprod(hjemmel, konsekvensForYtelsen, innvilget && revurdering);
+        return formaterLovhjemlerForBeregning(hjemmel, konsekvensForYtelsen, innvilget && revurdering, behandling);
 
     }
-
 }

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/domene/FellesMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/datamapper/domene/FellesMapperTest.java
@@ -4,12 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.beregningsgrunnlag.Hjemmel;
 import no.nav.foreldrepenger.melding.integrasjon.dokument.innvilget.foreldrepenger.KonsekvensForYtelseKode;
-import no.nav.foreldrepenger.melding.typer.Saksnummer;
 
 public class FellesMapperTest {
 
@@ -34,13 +35,25 @@ public class FellesMapperTest {
     @Test
     public void formaterLovhjemlerUdefinert() {
         String lovhjemmelFraBeregning = Hjemmel.UDEFINERT.getNavn();
-        assertLovformateringBeregning(lovhjemmelFraBeregning, "", false, FellesMapper.UDEFINERT);
+        assertLovformateringBeregning(lovhjemmelFraBeregning, "", false, "");
     }
 
     @Test
     public void formaterLovhjemlerNull() {
         String lovhjemmelFraBeregning = null;
-        assertLovformateringBeregning(lovhjemmelFraBeregning, "", false, FellesMapper.UDEFINERT);
+        assertLovformateringBeregning(lovhjemmelFraBeregning, "", false, "");
+    }
+
+    @Test
+    public void formaterLovhjemlerRevurderingEndringBeregningOgLovhjemmelUdefinertFraBeregning() {
+        String lovhjemmelFraBeregning = Hjemmel.UDEFINERT.getNavn();
+        assertLovformateringBeregning(lovhjemmelFraBeregning, KonsekvensForYtelseKode.ENDRING_I_BEREGNING.value(), false, " og forvaltningsloven § 35");
+    }
+
+    @Test
+    public void formaterLovhjemlerRevurderingEndringBeregningOgLovhjemmelNullFraBeregning() {
+        String lovhjemmelFraBeregning = null;
+        assertLovformateringBeregning(lovhjemmelFraBeregning, KonsekvensForYtelseKode.ENDRING_I_BEREGNING.value(), false, " og forvaltningsloven § 35");
     }
 
     @Test
@@ -71,7 +84,7 @@ public class FellesMapperTest {
     }
 
     private void assertLovformateringBeregning(String input, String konsekvensForYtelse, boolean innvilgetRevurdering, String forventetOutput) {
-        String lovhjemler = FellesMapper.formaterLovhjemlerForBeregning(input, konsekvensForYtelse, innvilgetRevurdering, new Saksnummer("123"));
+        String lovhjemler = FellesMapper.formaterLovhjemlerForBeregning(input, konsekvensForYtelse, innvilgetRevurdering, Behandling.builder().medUuid(UUID.randomUUID()).build());
         assertThat(lovhjemler).isEqualTo(forventetOutput);
     }
 }


### PR DESCRIPTION
…UDEFINERT, slik at linjen vil vises for revurderinger, men uten lovhjemler fra beregning.