### PR TITLE
TFP-4622 Lagt til håndtering av fritt uttak

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/avslagfp/ForeldrepengerAvslagDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/avslagfp/ForeldrepengerAvslagDokumentdataMapper.java
@@ -90,7 +90,8 @@ public class ForeldrepengerAvslagDokumentdataMapper implements DokumentdataMappe
                 .medAnnenForelderHarRett(uttakResultatPerioder.map(UttakResultatPerioder::isAnnenForelderHarRett).orElse(false))
                 .medAntallBarn(familiehendelse.getAntallBarn().intValue())
                 .medHalvG(halvG)
-                .medKlagefristUker(brevParametere.getKlagefristUker());
+                .medKlagefristUker(brevParametere.getKlagefristUker())
+                .medKreverSammenhengendeUttak(domeneobjektProvider.kreverSammenhengendeUttak(behandling));
 
         mapAvslåttePerioder(behandling, dokumentdataBuilder, uttakResultatPerioder);
 

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
@@ -152,6 +152,7 @@ public class ForeldrepengerInnvilgelseDokumentdataMapper implements Dokumentdata
                 .medForeldrepengeperiodenUtvidetUker(finnForeldrepengeperiodenUtvidetUkerHvisFinnes(saldoer))
                 .medAntallBarn(familieHendelse.getAntallBarn().intValue())
                 .medPrematurDager(finnPrematurDagerHvisFinnes(saldoer))
+                .medKreverSammenhengendeUttak(domeneobjektProvider.kreverSammenhengendeUttak(behandling))
                 .medUtbetalingsperioder(utbetalingsperioder)
 
                 .medKlagefristUker(brevParametere.getKlagefristUker())

--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/DomeneobjektProvider.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/datamapper/DomeneobjektProvider.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.fpsak.Behandlinger;
 import no.nav.foreldrepenger.fpsak.dto.anke.AnkebehandlingDto;
 import no.nav.foreldrepenger.fpsak.dto.klage.KlagebehandlingDto;
+import no.nav.foreldrepenger.fpsak.dto.uttak.KreverSammenhengendeUttakDto;
 import no.nav.foreldrepenger.melding.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.melding.anke.Anke;
 import no.nav.foreldrepenger.melding.behandling.Behandling;
@@ -197,6 +198,10 @@ public class DomeneobjektProvider {
         return behandlingRestKlient.hentInnvilgelseForeldrepengerDokumentmal(behandling.getResourceLinker())
                 .map(dto -> DokumentMalType.fraKode(dto.dokumentMalTypeKode()))
                 .orElse(DokumentMalType.INNVILGELSE_FORELDREPENGER_DOK);
+    }
+    public boolean kreverSammenhengendeUttak(Behandling behandling) {
+        return behandlingRestKlient.kreverSammenhengendeUttak(behandling.getResourceLinker()).kreverSammenhengendeUttak();
+
     }
 
 }

--- a/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/Behandlinger.java
+++ b/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/Behandlinger.java
@@ -23,6 +23,7 @@ import no.nav.foreldrepenger.fpsak.dto.klage.KlagebehandlingDto;
 import no.nav.foreldrepenger.fpsak.dto.klage.MottattKlagedokumentDto;
 import no.nav.foreldrepenger.fpsak.dto.personopplysning.VergeDto;
 import no.nav.foreldrepenger.fpsak.dto.soknad.SoknadBackendDto;
+import no.nav.foreldrepenger.fpsak.dto.uttak.KreverSammenhengendeUttakDto;
 import no.nav.foreldrepenger.fpsak.dto.uttak.UttakResultatPerioderDto;
 import no.nav.foreldrepenger.fpsak.dto.uttak.saldo.SaldoerDto;
 import no.nav.foreldrepenger.fpsak.dto.uttak.svp.SvangerskapspengerUttakResultatDto;
@@ -261,6 +262,15 @@ public interface Behandlinger {
                 .filter(dto -> "dokmal-innvfp".equals(dto.getRel()))
                 .findFirst()
                 .flatMap(link -> hentDtoFraLink(link, DokumentMalTypeDto.class));
+    }
+
+    default KreverSammenhengendeUttakDto kreverSammenhengendeUttak(List<BehandlingResourceLink> resourceLinker) {
+        return resourceLinker
+                .stream()
+                .filter(dto -> "krever-sammenhengende-uttak".equals(dto.getRel()))
+                .findFirst()
+                .flatMap(link -> hentDtoFraLink(link, KreverSammenhengendeUttakDto.class))
+                .orElseThrow(() -> new IllegalStateException("Klarte ikke hente om behandlingen krever sammenhengende uttak: " + hentBehandlingId(resourceLinker)));
     }
 
     private static UUID hentBehandlingId(List<BehandlingResourceLink> resourceLinker) {

--- a/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/dto/uttak/KreverSammenhengendeUttakDto.java
+++ b/domenetjenester/fpsak/src/main/java/no/nav/foreldrepenger/fpsak/dto/uttak/KreverSammenhengendeUttakDto.java
@@ -1,0 +1,4 @@
+package no.nav.foreldrepenger.fpsak.dto.uttak;
+
+public record KreverSammenhengendeUttakDto(boolean kreverSammenhengendeUttak) {
+}

--- a/domenetjenester/poststed/src/main/java/no/nav/foreldrepenger/melding/poststed/KodeverkTjeneste.java
+++ b/domenetjenester/poststed/src/main/java/no/nav/foreldrepenger/melding/poststed/KodeverkTjeneste.java
@@ -81,7 +81,7 @@ public class KodeverkTjeneste {
     }
 
     private Map<String, KodeverkKode> oversettFraHentKodeverkResponse(HentKodeverkResponse response) {
-        if (response.getKodeverk()instanceof EnkeltKodeverk e) {
+        if (response.getKodeverk()instanceof EnkeltKodeverk) {
             return ((EnkeltKodeverk) response.getKodeverk()).getKode().stream()
                     .map(KodeverkTjeneste::oversettFraKode)
                     .collect(Collectors.toMap(KodeverkKode::getKode, kodeverkKode -> kodeverkKode));

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/avslagfp/ForeldrepengerAvslagDokumentdata.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/avslagfp/ForeldrepengerAvslagDokumentdata.java
@@ -20,6 +20,7 @@ public class ForeldrepengerAvslagDokumentdata extends Dokumentdata {
     private int klagefristUker;
     private String lovhjemmelForAvslag;
     private int antallPerioder;
+    private boolean kreverSammenhengendeUttak;
     private List<AvslåttPeriode> avslåttePerioder;
 
     public String getRelasjonskode() {
@@ -62,6 +63,10 @@ public class ForeldrepengerAvslagDokumentdata extends Dokumentdata {
         return antallPerioder;
     }
 
+    public boolean getKreverSammenhengendeUttak() {
+        return kreverSammenhengendeUttak;
+    }
+
     public List<AvslåttPeriode> getAvslåttePerioder() {
         return avslåttePerioder;
     }
@@ -82,13 +87,14 @@ public class ForeldrepengerAvslagDokumentdata extends Dokumentdata {
                 && Objects.equals(klagefristUker, that.klagefristUker)
                 && Objects.equals(lovhjemmelForAvslag, that.lovhjemmelForAvslag)
                 && Objects.equals(antallPerioder, that.antallPerioder)
+                && Objects.equals(kreverSammenhengendeUttak, that.kreverSammenhengendeUttak)
                 && Objects.equals(avslåttePerioder, that.avslåttePerioder);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(felles, relasjonskode, mottattDato, gjelderFødsel, barnErFødt, annenForelderHarRett,
-                antallBarn, halvG, klagefristUker, lovhjemmelForAvslag, antallPerioder, avslåttePerioder);
+                antallBarn, halvG, klagefristUker, lovhjemmelForAvslag, antallPerioder, kreverSammenhengendeUttak, avslåttePerioder);
     }
 
     public static Builder ny() {
@@ -154,6 +160,11 @@ public class ForeldrepengerAvslagDokumentdata extends Dokumentdata {
 
         public Builder medAntallPerioder(int antallPerioder) {
             this.kladd.antallPerioder = antallPerioder;
+            return this;
+        }
+
+        public Builder medKreverSammenhengendeUttak(boolean kreverSammenhengendeUttak) {
+            this.kladd.kreverSammenhengendeUttak = kreverSammenhengendeUttak;
             return this;
         }
 

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdata.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdata.java
@@ -51,6 +51,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
     private int prematurDager;
     private int antallDødeBarn;
     private String dødsdato;
+    private boolean kreverSammenhengendeUttak;
 
     private List<Utbetalingsperiode> perioder = new ArrayList<>();
 
@@ -228,6 +229,10 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
         return dødsdato;
     }
 
+    public boolean getKreverSammenhengendeUttak() {
+        return kreverSammenhengendeUttak;
+    }
+
     public List<Utbetalingsperiode> getPerioder() {
         return perioder;
     }
@@ -316,6 +321,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
                 && Objects.equals(prematurDager, that.prematurDager)
                 && Objects.equals(antallDødeBarn, that.antallDødeBarn)
                 && Objects.equals(dødsdato, that.dødsdato)
+                && Objects.equals(kreverSammenhengendeUttak, that.kreverSammenhengendeUttak)
                 && Objects.equals(perioder, that.perioder)
                 && Objects.equals(bruttoBeregningsgrunnlag, that.bruttoBeregningsgrunnlag)
                 && Objects.equals(harBruktBruttoBeregningsgrunnlag, that.harBruktBruttoBeregningsgrunnlag)
@@ -338,7 +344,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
                 gjelderMor, gjelderFødsel, erBesteberegning, ingenRefusjon, delvisRefusjon, fullRefusjon, fbEllerRvInnvilget,
                 antallPerioder, antallInnvilgedePerioder, antallAvslåttePerioder, antallArbeidsgivere, dagerTaptFørTermin, disponibleDager,
                 disponibleFellesDager, sisteDagAvSistePeriode, stønadsperiodeFom, stønadsperiodeTom, foreldrepengeperiodenUtvidetUker,
-                antallBarn, prematurDager, antallDødeBarn, dødsdato, perioder, bruttoBeregningsgrunnlag, harBruktBruttoBeregningsgrunnlag, beregningsgrunnlagregler,
+                antallBarn, prematurDager, antallDødeBarn, dødsdato, kreverSammenhengendeUttak, perioder, bruttoBeregningsgrunnlag, harBruktBruttoBeregningsgrunnlag, beregningsgrunnlagregler,
                 klagefristUker, lovhjemlerUttak, lovhjemlerBeregning, inkludereUtbetaling, inkludereUtbetNårGradering, inkludereInnvilget,
                 inkludereAvslag, inkludereNyeOpplysningerUtbet);
     }
@@ -556,6 +562,11 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
 
         public Builder medDødsdato(String dødsdato) {
             this.kladd.dødsdato = dødsdato;
+            return this;
+        }
+
+        public Builder medKreverSammenhengendeUttak(boolean kreverSammenhengendeUttak) {
+            this.kladd.kreverSammenhengendeUttak = kreverSammenhengendeUttak;
             return this;
         }
 


### PR DESCRIPTION
Henter "krever-sammenhengende-uttak" fra fpsak slik at vi kan vite om en sak har fritt uttak eller ikke. Mapper verdien KreverSammenhengendeUttak på innvilgelse og avslag foreldrepenger.