### PR TITLE
TFP-4623 Lagt til håndtering av fritt uttak

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapper.java
@@ -1,11 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev;
 
-import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.opprettFellesBuilder;
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.melding.brevmapper.DokumentdataMapper;
@@ -19,6 +13,12 @@ import no.nav.foreldrepenger.melding.geografisk.Språkkode;
 import no.nav.foreldrepenger.melding.hendelser.DokumentHendelse;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.VarselOmRevurderingDokumentdata;
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.DokumentMalTypeKode;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.opprettFellesBuilder;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
 
 @ApplicationScoped
 @DokumentMalTypeRef(DokumentMalTypeKode.VARSEL_OM_REVURDERING)
@@ -59,7 +59,8 @@ public class VarselOmRevurderingDokumentdataMapper implements DokumentdataMapper
                 .medFristDato(formaterDato(brevMapperUtil.getSvarFrist(), behandling.getSpråkkode()))
                 .medAntallBarn(familieHendelse.getAntallBarn().intValue())
                 .medAdvarselKode(advarselKode)
-                .medFlereOpplysninger(utledFlereOpplysninger(hendelse, advarselKode));
+                .medFlereOpplysninger(utledFlereOpplysninger(hendelse, advarselKode))
+                .medKreverSammenhengendeUttak(domeneobjektProvider.kreverSammenhengendeUttak(behandling));
 
         return dokumentdataBuilder.build();
     }

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapperTest.java
@@ -1,33 +1,6 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev;
 
-import static java.util.List.of;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.VERGES_NAVN;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
-import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.Optional;
-import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
+import no.nav.foreldrepenger.fpsak.dto.uttak.KreverSammenhengendeUttakDto;
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.BehandlingType;
 import no.nav.foreldrepenger.melding.behandling.Behandlingsresultat;
@@ -46,6 +19,33 @@ import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.VarselOmRevurderingD
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingResultatType;
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.BehandlingÅrsakType;
 import no.nav.foreldrepenger.melding.kodeverk.kodeverdi.DokumentMalType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.VERGES_NAVN;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
+import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class VarselOmRevurderingDokumentdataMapperTest {
@@ -71,6 +71,8 @@ public class VarselOmRevurderingDokumentdataMapperTest {
 
         FamilieHendelse familieHendelse = opprettFamiliehendelse();
         when(domeneobjektProvider.hentFamiliehendelse(any(Behandling.class))).thenReturn(familieHendelse);
+        KreverSammenhengendeUttakDto kreverSammenhengendeUttak = new KreverSammenhengendeUttakDto(true);
+        when(domeneobjektProvider.kreverSammenhengendeUttak(any())).thenReturn(kreverSammenhengendeUttak.kreverSammenhengendeUttak());
     }
 
     @Test
@@ -102,6 +104,7 @@ public class VarselOmRevurderingDokumentdataMapperTest {
         assertThat(varselOmRevurderingDokumentdata.getAntallBarn()).isEqualTo(ANTALL_BARN);
         assertThat(varselOmRevurderingDokumentdata.getAdvarselKode()).isEqualTo(RevurderingVarslingÅrsak.ARBEIDS_I_STØNADSPERIODEN.getKode());
         assertThat(varselOmRevurderingDokumentdata.getFlereOpplysninger()).isFalse();
+        assertThat(varselOmRevurderingDokumentdata.getKreverSammenhengendeUttak()).isTrue();
     }
 
     @Test

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/VarselOmRevurderingDokumentdata.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/VarselOmRevurderingDokumentdata.java
@@ -1,8 +1,8 @@
 package no.nav.foreldrepenger.melding.integrasjon.dokgen.dto;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+import java.util.Objects;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class VarselOmRevurderingDokumentdata extends Dokumentdata {
@@ -11,6 +11,7 @@ public class VarselOmRevurderingDokumentdata extends Dokumentdata {
     private int antallBarn;
     private String advarselKode;
     private boolean flereOpplysninger;
+    private boolean kreverSammenhengendeUttak;
 
     public String getTerminDato() {
         return terminDato;
@@ -32,6 +33,10 @@ public class VarselOmRevurderingDokumentdata extends Dokumentdata {
         return flereOpplysninger;
     }
 
+    public boolean getKreverSammenhengendeUttak() {
+        return kreverSammenhengendeUttak;
+    }
+
     @Override
     public boolean equals(Object object) {
         if (this == object) return true;
@@ -42,12 +47,13 @@ public class VarselOmRevurderingDokumentdata extends Dokumentdata {
                 && Objects.equals(fristDato, that.fristDato)
                 && Objects.equals(antallBarn, that.antallBarn)
                 && Objects.equals(advarselKode, that.advarselKode)
-                && Objects.equals(flereOpplysninger, that.flereOpplysninger);
+                && Objects.equals(flereOpplysninger, that.flereOpplysninger)
+                && Objects.equals(kreverSammenhengendeUttak, that.kreverSammenhengendeUttak);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(felles, terminDato, fristDato, antallBarn, advarselKode, flereOpplysninger);
+        return Objects.hash(felles, terminDato, fristDato, antallBarn, advarselKode, flereOpplysninger, kreverSammenhengendeUttak);
     }
 
     public static Builder ny() {
@@ -88,6 +94,11 @@ public class VarselOmRevurderingDokumentdata extends Dokumentdata {
 
         public Builder medFlereOpplysninger(boolean flereOpplysninger) {
             this.kladd.flereOpplysninger = flereOpplysninger;
+            return this;
+        }
+
+        public Builder medKreverSammenhengendeUttak(boolean kreverSammenhengendeUttak) {
+            this.kladd.kreverSammenhengendeUttak = kreverSammenhengendeUttak;
             return this;
         }
 


### PR DESCRIPTION
Lagt til parameteren kreverSammenhengendeUttak på mapping av VarselOmRevurderingDokumentdataMapper slik at brevet kan gi riktig tekst ved varslingsårsak ARBEIDS_I_STØNADSPERIODEN.