### PR TITLE
TFP-4656 Rettelse for varsling revurdering

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapper.java
@@ -52,6 +52,13 @@ public class VarselOmRevurderingDokumentdataMapper implements DokumentdataMapper
 
         FamilieHendelse familieHendelse = domeneobjektProvider.hentFamiliehendelse(behandling);
 
+        //Om behandlingen krever sammenhengende uttak er nødvendig å vite på foreldrepenger, men brukes ikke for svp eller es
+        boolean kreverSammenhengendeUttak = true;
+
+        if (FagsakYtelseType.FORELDREPENGER.equals(hendelse.getYtelseType())) {
+            kreverSammenhengendeUttak = domeneobjektProvider.kreverSammenhengendeUttak(behandling);
+        }
+
         String advarselKode = utledAdvarselkode(hendelse);
         var dokumentdataBuilder = VarselOmRevurderingDokumentdata.ny()
                 .medFelles(fellesBuilder.build())
@@ -60,7 +67,7 @@ public class VarselOmRevurderingDokumentdataMapper implements DokumentdataMapper
                 .medAntallBarn(familieHendelse.getAntallBarn().intValue())
                 .medAdvarselKode(advarselKode)
                 .medFlereOpplysninger(utledFlereOpplysninger(hendelse, advarselKode))
-                .medKreverSammenhengendeUttak(domeneobjektProvider.kreverSammenhengendeUttak(behandling));
+                .medKreverSammenhengendeUttak(kreverSammenhengendeUttak);
 
         return dokumentdataBuilder.build();
     }

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/VarselOmRevurderingDokumentdataMapperTest.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev;
 
-import no.nav.foreldrepenger.fpsak.dto.uttak.KreverSammenhengendeUttakDto;
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.BehandlingType;
 import no.nav.foreldrepenger.melding.behandling.Behandlingsresultat;
@@ -71,8 +70,7 @@ public class VarselOmRevurderingDokumentdataMapperTest {
 
         FamilieHendelse familieHendelse = opprettFamiliehendelse();
         when(domeneobjektProvider.hentFamiliehendelse(any(Behandling.class))).thenReturn(familieHendelse);
-        KreverSammenhengendeUttakDto kreverSammenhengendeUttak = new KreverSammenhengendeUttakDto(true);
-        when(domeneobjektProvider.kreverSammenhengendeUttak(any())).thenReturn(kreverSammenhengendeUttak.kreverSammenhengendeUttak());
+        when(domeneobjektProvider.kreverSammenhengendeUttak(any())).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
Rettet at det forsøkes å hente krever-sammenhengende-uttak for svangerskapspenger og engangsstønad når det bestilles varslingsbrev revurdering. Tjenesten gjelder kun foreldrepenger, og er derfor ikke tilgjengelig for es og svp.