### PR TITLE
FIX opphør foreldrepenger

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenLanseringTjeneste.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevbestiller/impl/DokgenLanseringTjeneste.java
@@ -35,7 +35,8 @@ public class DokgenLanseringTjeneste {
             DokumentMalType.KLAGE_OMGJORT,
             DokumentMalType.KLAGE_OVERSENDT,
             DokumentMalType.KLAGE_STADFESTET,
-            DokumentMalType.FORELDREPENGER_ANNULLERT);
+            DokumentMalType.FORELDREPENGER_ANNULLERT,
+            DokumentMalType.FORELDREPENGER_OPPHØR);
     private static final Set<DokumentMalType> DOKGEN_MALER_DEV = Set.of(
             DokumentMalType.ENGANGSSTØNAD_INNVILGELSE,
             DokumentMalType.ENGANGSSTØNAD_AVSLAG,


### PR DESCRIPTION
FORELDREPENGER_OPPHØR var ved en feiltagelse fjernet fra DOKGEN_MALER_PROD som gjorde at dette brevet feilet