### PR TITLE
TFP-4791 Opphør svp - ved død

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/SvangerskapspengerOpphørDokumentdataMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/SvangerskapspengerOpphørDokumentdataMapper.java
@@ -2,6 +2,8 @@ package no.nav.foreldrepenger.melding.brevmapper.brev.opphørsvp;
 
 import no.nav.foreldrepenger.melding.Tuple;
 import no.nav.foreldrepenger.melding.behandling.Behandling;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
 import no.nav.foreldrepenger.melding.brevmapper.DokumentdataMapper;
 import no.nav.foreldrepenger.melding.brevmapper.brev.felles.SvpMapperUtil;
 import no.nav.foreldrepenger.melding.datamapper.DomeneobjektProvider;
@@ -56,6 +58,7 @@ public class SvangerskapspengerOpphørDokumentdataMapper implements Dokumentdata
         var svpUttaksresultat = domeneobjektProvider.hentUttaksresultatSvpHvisFinnes(behandling);
         var familieHendelse = domeneobjektProvider.hentFamiliehendelse(behandling);
         var iay = domeneobjektProvider.hentInntektArbeidYtelse(behandling);
+        var tilkjentYtelsePerioder = domeneobjektProvider.hentBeregningsresultatFPHvisFinnes(behandling).map(BeregningsresultatFP::getBeregningsresultatPerioder).orElse(Collections.emptyList());
 
         Språkkode språkkode = behandling.getSpråkkode();
 
@@ -73,7 +76,7 @@ public class SvangerskapspengerOpphørDokumentdataMapper implements Dokumentdata
 
          mapOpphørtPeriodeOgLovhjemmel(dokumentdatabuilder, behandling,
                 svpUttaksresultat.map(SvpUttaksresultat::getUttakResultatArbeidsforhold).orElse(Collections.emptyList()),
-                 språkkode, iay);
+                 språkkode, iay, tilkjentYtelsePerioder);
 
         SvpMapperUtil.finnFørsteUttakssdato(uttaksperioder, behandling.getBehandlingsresultat())
                  .ifPresent(d -> dokumentdatabuilder.medOpphørsdato(formaterDato(d, språkkode)));
@@ -85,10 +88,9 @@ public class SvangerskapspengerOpphørDokumentdataMapper implements Dokumentdata
         return dokumentdatabuilder.build();
     }
 
-    private void mapOpphørtPeriodeOgLovhjemmel(SvangerskapspengerOpphørDokumentdata.Builder dokumentdataBuilder, Behandling behandling,
-                                               List<SvpUttakResultatArbeidsforhold> uttakResultatArbeidsforhold, Språkkode språkKode, InntektArbeidYtelse iay) {
+    private void mapOpphørtPeriodeOgLovhjemmel(SvangerskapspengerOpphørDokumentdata.Builder dokumentdataBuilder, Behandling behandling, List<SvpUttakResultatArbeidsforhold> uttakResultatArbeidsforhold, Språkkode språkKode, InntektArbeidYtelse iay, List <BeregningsresultatPeriode> tilkjentYtelsePerioder) {
 
-        Tuple <OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakResultatArbeidsforhold, språkKode, iay);
+        Tuple <OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakResultatArbeidsforhold, språkKode, iay, tilkjentYtelsePerioder);
 
         dokumentdataBuilder.medLovhjemmel(opphørtePerioderOgLovhjemmel.element2());
         dokumentdataBuilder.medOpphørPerioder(opphørtePerioderOgLovhjemmel.element1());

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapperTest.java
@@ -3,6 +3,10 @@ package no.nav.foreldrepenger.melding.brevmapper.brev.opphørsvp;
 import no.nav.foreldrepenger.melding.Tuple;
 import no.nav.foreldrepenger.melding.behandling.Behandling;
 import no.nav.foreldrepenger.melding.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatAndel;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatFP;
+import no.nav.foreldrepenger.melding.beregning.BeregningsresultatPeriode;
+import no.nav.foreldrepenger.melding.beregningsgrunnlag.AktivitetStatus;
 import no.nav.foreldrepenger.melding.geografisk.Språkkode;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Årsak;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.opphørsvp.OpphørPeriode;
@@ -17,27 +21,32 @@ import no.nav.foreldrepenger.melding.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static java.util.List.of;
 import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
+import static no.nav.foreldrepenger.melding.typer.DatoIntervall.fraOgMedTilOgMed;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-class OpphørsperiodeMapperTest {
+class OpphørPeriodeMapperTest {
     private static final LocalDate PERIODE1_FOM = LocalDate.now().minusDays(10);
     private static final LocalDate PERIODE1_TOM = LocalDate.now().plusDays(5);
     private static final LocalDate PERIODE2_FOM = LocalDate.now().plusDays(6);
     private static final LocalDate PERIODE2_TOM = LocalDate.now().plusDays(10);
-    private static final String ARBGIVER_2 = "Arbeidsgiver2";
-    private static final String ARBGIVER_1 = "Arbeidsgiver1";
+    private static final String ARBGIVER_2_NAVN = "Arbeidsgiver2";
+    private static final String ARBGIVER_1_NAVN = "Arbeidsgiver1";
+    private static final Arbeidsgiver ARBEIDSGIVER_1 = new Arbeidsgiver("123456", ARBGIVER_1_NAVN );
+    private static final Arbeidsgiver ARBEIDSGIVER_2 = new Arbeidsgiver("123457", ARBGIVER_2_NAVN );
     private static final String LOVHJEMLER = "§ 14-4 og forvaltningsloven § 35";
 
     @Test
-    public void  en_opphørt_periode_uten_perioder() {
+    public void  opphør_uten_uttak_og_tilkjent_ytelse() {
         //Arrange
-        List<SvpUttakResultatArbeidsforhold> svpUttakResultatArbeidsforholdList = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, new Arbeidsgiver("1234", ARBGIVER_1), Collections.emptyList()));
+        List<SvpUttakResultatArbeidsforhold> svpUttakResultatArbeidsforholdList = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, ARBEIDSGIVER_1, Collections.emptyList()));
 
         Behandling behandling  = standardBehandlingBuilder()
                 .medBehandlingsresultat(Behandlingsresultat.builder()
@@ -46,7 +55,7 @@ class OpphørsperiodeMapperTest {
                 .build();
 
         //Act
-        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, svpUttakResultatArbeidsforholdList, Språkkode.NB, null);
+        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, svpUttakResultatArbeidsforholdList, Språkkode.NB, null, Collections.emptyList());
 
         //Assert
         OpphørPeriode opphørtPeriode = opphørtePerioderOgLovhjemmel.element1();
@@ -63,16 +72,19 @@ class OpphørsperiodeMapperTest {
     @Test
     public void  en_opphørt_Periode_med_en_arbeidsgiver() {
         //Arrange
-        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, new Arbeidsgiver("1234", ARBGIVER_1),
-                List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_1, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )),
-                        opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8309, ARBGIVER_1, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )))));
-
         Behandling behandling  = standardBehandlingBuilder()
                 .medBehandlingsresultat(Behandlingsresultat.builder()
                         .build())
                 .build();
+
+        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, ARBEIDSGIVER_1,
+                List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_1_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )),
+                        opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8309, ARBGIVER_1_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )))));
+
+        List<BeregningsresultatPeriode> tilkjentYtelsePerioder = opprettBeregningsresultat(1).getBeregningsresultatPerioder();
+
         //Act
-        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null);
+        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null, tilkjentYtelsePerioder);
 
         //Assert
         OpphørPeriode opphørtPeriode = opphørtePerioderOgLovhjemmel.element1();
@@ -81,7 +93,7 @@ class OpphørsperiodeMapperTest {
         assertThat(opphørtPeriode).isNotNull();
         assertThat(opphørtPeriode.getÅrsak()).isEqualTo(Årsak.of(PeriodeIkkeOppfyltÅrsak._8309.getKode()));
         assertThat(opphørtPeriode.getAntallArbeidsgivere()).isEqualTo(1);
-        assertThat(opphørtPeriode.getStønadsperiodeFom()).isEqualTo(formaterDato(PERIODE2_FOM, Språkkode.NB));
+        assertThat(opphørtPeriode.getStønadsperiodeFom()).isEqualTo(formaterDato(PERIODE1_FOM, Språkkode.NB));
         assertThat(opphørtPeriode.getStønadsperiodeTom()).isEqualTo(formaterDato(PERIODE2_TOM, Språkkode.NB));
 
     }
@@ -89,19 +101,22 @@ class OpphørsperiodeMapperTest {
     @Test
     public void  en_opphørt_periode_med_2_arbeidsgivere() {
         //Arrange
-        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, new Arbeidsgiver("1234", ARBGIVER_1),
-                List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_1, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )),
-                        opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8304, ARBGIVER_1, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )))
-        ), opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, new Arbeidsgiver("4567", ARBGIVER_2),
-                        List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_2, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )),
-                                opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8304, ARBGIVER_2, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )))));
-
         Behandling behandling  = standardBehandlingBuilder()
                 .medBehandlingsresultat(Behandlingsresultat.builder()
                         .build())
                 .build();
+
+        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, ARBEIDSGIVER_1,
+                List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_1_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )),
+                        opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8304, ARBGIVER_1_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM )))
+        ), opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.INGEN, ARBEIDSGIVER_2,
+                        List.of(opprettUttaksperiode(PeriodeResultatType.INNVILGET, null, ARBGIVER_2_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )),
+                                opprettUttaksperiode(PeriodeResultatType.AVSLÅTT, PeriodeIkkeOppfyltÅrsak._8304, ARBGIVER_2_NAVN, DatoIntervall.fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM )))));
+
+        List<BeregningsresultatPeriode> tilkjentYtelsePerioder = opprettBeregningsresultat(2).getBeregningsresultatPerioder();
+
         //Act
-        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null);
+        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null, tilkjentYtelsePerioder);
 
         //Assert
         OpphørPeriode opphørtPeriode = opphørtePerioderOgLovhjemmel.element1();
@@ -115,27 +130,51 @@ class OpphørsperiodeMapperTest {
         assertThat(opphørtPeriode.getStønadsperiodeTom()).isEqualTo(formaterDato(PERIODE2_TOM, Språkkode.NB));
     }
 
-
     @Test
     public void  en_opphørsperiode_pga_avslag_på_arbeidsforholdet() {
         //Arrange
-        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.ARBEIDSGIVER_KAN_TILRETTELEGGE, new Arbeidsgiver("1234", ARBGIVER_1), Collections.emptyList()));
+        List<SvpUttakResultatArbeidsforhold> uttakArbeidsforhold = List.of(opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak.ARBEIDSGIVER_KAN_TILRETTELEGGE, ARBEIDSGIVER_1, Collections.emptyList()));
 
         Behandling behandling  = standardBehandlingBuilder()
                 .medBehandlingsresultat(Behandlingsresultat.builder()
                         .build())
                 .build();
         //Act
-        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null);
+        Tuple<OpphørPeriode, String> opphørtePerioderOgLovhjemmel = OpphørPeriodeMapper.mapOpphørtePerioderOgLovhjemmel(behandling, uttakArbeidsforhold, Språkkode.NB, null, Collections.emptyList());
 
         //Assert
         OpphørPeriode opphørtPeriode = opphørtePerioderOgLovhjemmel.element1();
         String lovhjemler = opphørtePerioderOgLovhjemmel.element2();
 
+        assertThat(lovhjemler).isEqualTo(LOVHJEMLER);
         assertThat(opphørtPeriode).isNotNull();
         assertThat(opphørtPeriode.getÅrsak()).isEqualTo(Årsak.of(ArbeidsforholdIkkeOppfyltÅrsak.ARBEIDSGIVER_KAN_TILRETTELEGGE.getKode()));
         assertThat(opphørtPeriode.getAntallArbeidsgivere()).isEqualTo(1);
 
+    }
+
+    private BeregningsresultatFP opprettBeregningsresultat(int antallArbeidsgivere) {
+        return BeregningsresultatFP.ny()
+                .leggTilBeregningsresultatPerioder(of(
+                        BeregningsresultatPeriode.ny()
+                                .medDagsats(500L)
+                                .medPeriode(fraOgMedTilOgMed(PERIODE1_FOM, PERIODE1_TOM))
+                                .medBeregningsresultatAndel(of(BeregningsresultatAndel.ny()
+                                        .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                                        .medArbeidsgiver(ARBEIDSGIVER_1)
+                                        .medStillingsprosent(BigDecimal.valueOf(50))
+                                        .build()))
+                                .build(),
+                        BeregningsresultatPeriode.ny()
+                                .medDagsats(300L)
+                                .medPeriode(fraOgMedTilOgMed(PERIODE2_FOM, PERIODE2_TOM))
+                                .medBeregningsresultatAndel(of(BeregningsresultatAndel.ny()
+                                        .medArbeidsgiver(antallArbeidsgivere == 1 ? ARBEIDSGIVER_1 : ARBEIDSGIVER_2)
+                                        .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                                        .medStillingsprosent(BigDecimal.valueOf(50))
+                                        .build()))
+                                .build()))
+                .build();
     }
 
     private SvpUttakResultatArbeidsforhold opprettUttakArbeidsforhold(ArbeidsforholdIkkeOppfyltÅrsak arbeidsforholdIkkeOppfyltÅrsak, Arbeidsgiver arbeidsgiver, List<SvpUttakResultatPeriode> perioder) {


### PR DESCRIPTION
Endret OpphørPeriodeMapper for svp til å hente første og siste stønadsdato fra beregningsresultatet og ikke utttaket da uttaket i noen tilfeller vil være feil (feks hvis bruker dør). Antagelig blir det mer riktig å hente fra tilkjent ytelse i alle tilfeller.