### PR TITLE
TFP-4791 Opphør svp - rettelse

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapper.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapper.java
@@ -132,11 +132,17 @@ public class OpphørPeriodeMapper {
     }
 
     private static Optional<LocalDate> finnFørsteStønadDato(List<BeregningsresultatPeriode> perioder) {
-        return perioder.stream().map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom).min(LocalDate::compareTo);
+        return perioder.stream()
+                .filter(p-> p.getDagsats() > 0)
+                .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom)
+                .min(LocalDate::compareTo);
     }
 
     private static Optional<LocalDate> finnSisteStønadDato(List<BeregningsresultatPeriode> perioder) {
-        return perioder.stream().map(BeregningsresultatPeriode::getBeregningsresultatPeriodeTom).max(LocalDate::compareTo);
+        return perioder.stream()
+                .filter(p-> p.getDagsats() > 0)
+                .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeTom)
+                .max(LocalDate::compareTo);
     }
 
     private static int finnAntallArbeidsgivereFraTilkjentYtelse(List<BeregningsresultatPeriode> perioder) {

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/opphørsvp/OpphørPeriodeMapperTest.java
@@ -173,6 +173,15 @@ class OpphørPeriodeMapperTest {
                                         .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
                                         .medStillingsprosent(BigDecimal.valueOf(50))
                                         .build()))
+                                .build(),
+                        BeregningsresultatPeriode.ny()
+                                .medDagsats(0L)
+                                .medPeriode(fraOgMedTilOgMed(LocalDate.now().plusDays(8), LocalDate.now().plusDays(12)))
+                                .medBeregningsresultatAndel(of(BeregningsresultatAndel.ny()
+                                        .medArbeidsgiver(antallArbeidsgivere == 1 ? ARBEIDSGIVER_1 : ARBEIDSGIVER_2)
+                                        .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                                        .medStillingsprosent(BigDecimal.valueOf(50))
+                                        .build()))
                                 .build()))
                 .build();
     }


### PR DESCRIPTION
Fjerner perioder hvor dagsats er 0 når jeg henter første og siste dato fra beregningsresultat for å få med faktiske utbetalingsperioder.