### PR TITLE
TFP-4778 Foreldrepenger innvilgelse

### DIFF
--- a/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMerger.java
+++ b/domenetjenester/brevbestiller/src/main/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/UtbetalingsperiodeMerger.java
@@ -1,16 +1,16 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.DatoVerktøy.erFomRettEtterTomDato;
-import static no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Årsak.erRegnetSomLike;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.AnnenAktivitet;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Arbeidsforhold;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Næring;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.AnnenAktivitet;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Arbeidsforhold;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Næring;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp.Utbetalingsperiode;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.DatoVerktøy.erFomRettEtterTomDato;
+import static no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Årsak.erRegnetSomLike;
 
 public final class UtbetalingsperiodeMerger {
 
@@ -55,6 +55,7 @@ public final class UtbetalingsperiodeMerger {
                 .medPeriodeDagsats(periodeEn.getPeriodeDagsats())
                 .medAntallTapteDager(periodeEn.getAntallTapteDager() + (periodeTo.getAntallTapteDager()))
                 .medPrioritertUtbetalingsgrad(periodeEn.getPrioritertUtbetalingsgrad())
+                .medStønadskontoType(periodeEn.getStønadskontoType())
                 .medArbeidsforhold(periodeEn.getArbeidsforholdsliste())
                 .medNæring(periodeEn.getNæring())
                 .medAnnenAktivitet(periodeEn.getAnnenAktivitetsliste())

--- a/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapperTest.java
+++ b/domenetjenester/brevbestiller/src/test/java/no/nav/foreldrepenger/melding/brevmapper/brev/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapperTest.java
@@ -1,39 +1,5 @@
 package no.nav.foreldrepenger.melding.brevmapper.brev.innvilgelsefp;
 
-import static java.util.List.of;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.BeregningsresultatMapper.finnDagsats;
-import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.BeregningsresultatMapper.finnMånedsbeløp;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
-import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
-import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
-import static no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Beløp.of;
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
-import static no.nav.foreldrepenger.melding.typer.DatoIntervall.fraOgMedTilOgMed;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import no.nav.foreldrepenger.melding.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.melding.aksjonspunkt.AksjonspunktStatus;
@@ -83,6 +49,39 @@ import no.nav.foreldrepenger.melding.uttak.kodeliste.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.melding.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.melding.ytelsefordeling.OppgittRettighet;
 import no.nav.foreldrepenger.melding.ytelsefordeling.YtelseFordeling;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.BeregningsresultatMapper.finnDagsats;
+import static no.nav.foreldrepenger.melding.brevmapper.brev.felles.BeregningsresultatMapper.finnMånedsbeløp;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.FRITEKST;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SAKSNUMMER;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_FNR;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.SØKERS_NAVN;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentData;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardDokumentFelles;
+import static no.nav.foreldrepenger.melding.datamapper.DatamapperTestUtil.lagStandardHendelseBuilder;
+import static no.nav.foreldrepenger.melding.datamapper.util.BrevMapperUtil.formaterPersonnummer;
+import static no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Beløp.of;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDatoNorsk;
+import static no.nav.foreldrepenger.melding.typer.DatoIntervall.fraOgMedTilOgMed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
@@ -92,8 +91,8 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
     private static final int DISPONIBLE_DAGER = 5;
     private static final int DISPONIBLE_DAGER_FELLES = 10;
     private static final int TAPTE_DAGER_FPFF = 2;
-    private static final LocalDate PERIODE_FOM = LocalDate.now().plusDays(2);
-    private static final LocalDate PERIODE_TOM = LocalDate.now().plusDays(3);
+    private static final LocalDate PERIODE_FOM = LocalDate.now().minusMonths(4);
+    private static final LocalDate PERIODE_TOM = LocalDate.now().minusMonths(4).plusDays(3);
     private static final int PREMATUR_DAGER = 2;
     private static final int KLAGEFRIST = 6;
     private static final int BRUTTO_BERENINGSGRUNNLAG = 400;
@@ -173,9 +172,9 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
         assertThat(dokumentdata.getIngenRefusjon()).isFalse();
         assertThat(dokumentdata.getFbEllerRvInnvilget()).isTrue();
         assertThat(dokumentdata.getFullRefusjon()).isFalse();
-        assertThat(dokumentdata.getAntallPerioder()).isEqualTo(3);
+        assertThat(dokumentdata.getAntallPerioder()).isEqualTo(4);
         assertThat(dokumentdata.getAntallInnvilgedePerioder()).isEqualTo(1);
-        assertThat(dokumentdata.getAntallAvslåttePerioder()).isEqualTo(2);
+        assertThat(dokumentdata.getAntallAvslåttePerioder()).isEqualTo(3);
         assertThat(dokumentdata.getAntallArbeidsgivere()).isEqualTo(1);
         assertThat(dokumentdata.getDagerTaptFørTermin()).isEqualTo(TAPTE_DAGER_FPFF);
         assertThat(dokumentdata.getDisponibleDager()).isEqualTo(DISPONIBLE_DAGER);
@@ -188,7 +187,9 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
         assertThat(dokumentdata.getPrematurDager()).isEqualTo(PREMATUR_DAGER);
         assertThat(dokumentdata.getAntallDødeBarn()).isEqualTo(0);
         assertThat(dokumentdata.getDødsdato()).isEqualTo(null);
-        assertThat(dokumentdata.getPerioder()).hasSize(3);
+        assertThat(dokumentdata.getMorKanSøkeOmDagerFørFødsel()).isTrue();
+        assertThat(dokumentdata.getPerioder()).hasSize(4);
+        assertThat(dokumentdata.getPerioder().get(0).getStønadskontoType()).isEqualTo(StønadskontoType.FORELDREPENGER);
 
         assertThat(dokumentdata.getKlagefristUker()).isEqualTo(KLAGEFRIST);
         assertThat(dokumentdata.getLovhjemlerUttak()).isEqualTo("forvaltningsloven § 35");
@@ -282,6 +283,14 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
                 .medUtbetalingsprosent(BigDecimal.ZERO)
                 .medUttakAktivitet(UttakAktivitet.ny().medUttakArbeidType(UttakArbeidType.ORDINÆRT_ARBEID).build())
                 .medArbeidsprosent(BigDecimal.valueOf(100))
+                .medTrekkonto(StønadskontoType.FORELDREPENGER)
+                .build();
+        UttakResultatPeriodeAktivitet uttakAktivitet1 = UttakResultatPeriodeAktivitet.ny()
+                .medTrekkdager(BigDecimal.TEN)
+                .medUtbetalingsprosent(BigDecimal.ZERO)
+                .medUttakAktivitet(UttakAktivitet.ny().medUttakArbeidType(UttakArbeidType.ORDINÆRT_ARBEID).build())
+                .medArbeidsprosent(BigDecimal.valueOf(200))
+                .medTrekkonto(StønadskontoType.FORELDREPENGER_FØR_FØDSEL)
                 .build();
         UttakResultatPeriode uttakResultatPeriode1 = UttakResultatPeriode.ny()
                 .medAktiviteter(of(uttakAktivitet))
@@ -296,8 +305,14 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
                 .medPeriodeResultatType(PeriodeResultatType.INNVILGET)
                 .medPeriodeResultatÅrsak(PeriodeResultatÅrsak.MOR_HAR_IKKE_OMSORG)
                 .build();
+        UttakResultatPeriode uttakResultatPeriode3 = UttakResultatPeriode.ny()
+                .medAktiviteter(of(uttakAktivitet1))
+                .medTidsperiode(fraOgMedTilOgMed(LocalDate.now(), LocalDate.now().plusDays(1)))
+                .medPeriodeResultatType(PeriodeResultatType.AVSLÅTT)
+                .medPeriodeResultatÅrsak(PeriodeResultatÅrsak.MOR_TAR_IKKE_ALLE_UKENE)
+                .build();
         return UttakResultatPerioder.ny()
-                .medPerioder(of(uttakResultatPeriode1, uttakResultatPeriode2))
+                .medPerioder(of(uttakResultatPeriode1, uttakResultatPeriode2, uttakResultatPeriode3))
                 .medAnnenForelderHarRett(true)
                 .medAleneomsorg(true)
                 .build();

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdata.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdata.java
@@ -1,14 +1,13 @@
 package no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Beløp;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Dokumentdata;
 import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.FellesDokumentdata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
@@ -54,6 +53,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
     private int antallDødeBarn;
     private String dødsdato;
     private boolean kreverSammenhengendeUttak;
+    private boolean morKanSøkeOmDagerFørFødsel;
 
     private List<Utbetalingsperiode> perioder = new ArrayList<>();
 
@@ -235,6 +235,10 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
         return kreverSammenhengendeUttak;
     }
 
+    public boolean getMorKanSøkeOmDagerFørFødsel() {
+        return morKanSøkeOmDagerFørFødsel;
+    }
+
     public List<Utbetalingsperiode> getPerioder() {
         return perioder;
     }
@@ -324,6 +328,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
                 && Objects.equals(antallDødeBarn, that.antallDødeBarn)
                 && Objects.equals(dødsdato, that.dødsdato)
                 && Objects.equals(kreverSammenhengendeUttak, that.kreverSammenhengendeUttak)
+                && Objects.equals(morKanSøkeOmDagerFørFødsel, that.morKanSøkeOmDagerFørFødsel)
                 && Objects.equals(perioder, that.perioder)
                 && Objects.equals(bruttoBeregningsgrunnlag, that.bruttoBeregningsgrunnlag)
                 && Objects.equals(harBruktBruttoBeregningsgrunnlag, that.harBruktBruttoBeregningsgrunnlag)
@@ -346,7 +351,7 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
                 gjelderMor, gjelderFødsel, erBesteberegning, ingenRefusjon, delvisRefusjon, fullRefusjon, fbEllerRvInnvilget,
                 antallPerioder, antallInnvilgedePerioder, antallAvslåttePerioder, antallArbeidsgivere, dagerTaptFørTermin, disponibleDager,
                 disponibleFellesDager, sisteDagAvSistePeriode, stønadsperiodeFom, stønadsperiodeTom, foreldrepengeperiodenUtvidetUker,
-                antallBarn, prematurDager, antallDødeBarn, dødsdato, kreverSammenhengendeUttak, perioder, bruttoBeregningsgrunnlag, harBruktBruttoBeregningsgrunnlag, beregningsgrunnlagregler,
+                antallBarn, prematurDager, antallDødeBarn, dødsdato, kreverSammenhengendeUttak, morKanSøkeOmDagerFørFødsel, perioder, bruttoBeregningsgrunnlag, harBruktBruttoBeregningsgrunnlag, beregningsgrunnlagregler,
                 klagefristUker, lovhjemlerUttak, lovhjemlerBeregning, inkludereUtbetaling, inkludereUtbetNårGradering, inkludereInnvilget,
                 inkludereAvslag, inkludereNyeOpplysningerUtbet);
     }
@@ -569,6 +574,11 @@ public class ForeldrepengerInnvilgelseDokumentdata extends Dokumentdata {
 
         public Builder medKreverSammenhengendeUttak(boolean kreverSammenhengendeUttak) {
             this.kladd.kreverSammenhengendeUttak = kreverSammenhengendeUttak;
+            return this;
+        }
+
+        public Builder medMorKanSøkeOmDagerFørFødsel(boolean morKanSøkeOmDagerFørFødsel) {
+            this.kladd.morKanSøkeOmDagerFørFødsel = morKanSøkeOmDagerFørFødsel;
             return this;
         }
 

--- a/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/Utbetalingsperiode.java
+++ b/integrasjon/dokgen-klient/src/main/java/no/nav/foreldrepenger/melding/integrasjon/dokgen/dto/innvilgelsefp/Utbetalingsperiode.java
@@ -1,24 +1,26 @@
 package no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.innvilgelsefp;
 
-import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import no.nav.foreldrepenger.melding.geografisk.Språkkode;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Prosent;
+import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Årsak;
+import no.nav.foreldrepenger.melding.uttak.StønadskontoType;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-import no.nav.foreldrepenger.melding.geografisk.Språkkode;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Prosent;
-import no.nav.foreldrepenger.melding.integrasjon.dokgen.dto.felles.Årsak;
+import static no.nav.foreldrepenger.melding.typer.Dato.formaterDato;
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public class Utbetalingsperiode {
     private boolean innvilget;
     private Årsak årsak;
+    @JsonIgnore
+    private StønadskontoType stønadskontoType;
     private String periodeFom;
     @JsonIgnore
     private LocalDate periodeFomDate;
@@ -46,6 +48,9 @@ public class Utbetalingsperiode {
         return årsak;
     }
 
+    public StønadskontoType getStønadskontoType() {
+        return stønadskontoType;
+    }
     public LocalDate getPeriodeFom() {
         return periodeFomDate;
     }
@@ -125,6 +130,11 @@ public class Utbetalingsperiode {
 
         public Builder medÅrsak(Årsak årsak) {
             this.kladd.årsak = årsak;
+            return this;
+        }
+
+        public Builder medStønadskontoType(StønadskontoType stønadskontoType) {
+            this.kladd.stønadskontoType = stønadskontoType;
             return this;
         }
 


### PR DESCRIPTION
Dersom periodelisten inneholder 4095(MOR_TAR_IKKE_ALLE_UKENE) sjekkes det om det fortsatt er mulig å søke om dagene som er avslått. Det sjekkes ved å se om første uttaksdato etter før_fødsel + 3 måneder er før dagens dato. I såtilfelle settes nytt felt: morKanSøkeOmDagerFørFødsel til true.