### PR TITLE
TFP-4778 FIX

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapper.java
@@ -200,7 +200,7 @@ public class ForeldrepengerInnvilgelseDokumentdataMapper implements Dokumentdata
                       .filter(up -> !StønadskontoType.FORELDREPENGER_FØR_FØDSEL.equals(up.getStønadskontoType()))
                       .map(Utbetalingsperiode::getPeriodeFom)
                       .min(LocalDate::compareTo)
-                      .map(md -> md.plusMonths(3).isBefore(LocalDate.now()))
+                      .map(md -> (LocalDate.now().isBefore(md.plusMonths(3))))
                       .orElse(false);
         }
 

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapperTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/innvilgelsefp/ForeldrepengerInnvilgelseDokumentdataMapperTest.java
@@ -92,8 +92,8 @@ public class ForeldrepengerInnvilgelseDokumentdataMapperTest {
     private static final int DISPONIBLE_DAGER = 5;
     private static final int DISPONIBLE_DAGER_FELLES = 10;
     private static final int TAPTE_DAGER_FPFF = 2;
-    private static final LocalDate PERIODE_FOM = LocalDate.now().minusMonths(4);
-    private static final LocalDate PERIODE_TOM = LocalDate.now().minusMonths(4).plusDays(3);
+    private static final LocalDate PERIODE_FOM = LocalDate.now().plusMonths(4);
+    private static final LocalDate PERIODE_TOM = LocalDate.now().plusMonths(4).plusDays(3);
     private static final int PREMATUR_DAGER = 2;
     private static final int KLAGEFRIST = 6;
     private static final int BRUTTO_BERENINGSGRUNNLAG = 400;


### PR DESCRIPTION
Rettet brist i logikk for å bestemme om tekst ved avslagsårsak 4095 skal vises eller ikke. Sjekker nå at dagens dato er før beregnet dato (beregnet dato = første dato i perioden som ikke er FØR_FØDSEL pluss 3 måneder).  Dersom det er tilfelle vil mor fortsatt kunne søke på avslått periode, og tekst vil vises i brevet.