### PR TITLE
Fix abac

### DIFF
--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -14,6 +14,7 @@ auditlogger.product=fpformidling
 
 # ABAC
 abac.pdp.endpoint.url=http://abac-foreldrepenger.teamabac/application/authorize
+abac.attributt.drift=no.nav.abac.attributter.foreldrepenger.drift
 
 ## Klienter
 # Verdikjede


### PR DESCRIPTION
IMHO bør det defaultes til "no.nav.abac.attributter.foreldrepenger.drift" om property eller ressurs ikke er satt eksplisitt i appen. Da slipper man å definere dette i hver app siden denne funksjonaliteten ble lagt til av FC til å støtte dagens ABAC implementasjon i abakus som bruker en annen drift ressurs id.