### PR TITLE
TFP-4953/Tfp-4944 Opphørsdato utledes ved å finne minste fra dato opp…

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
@@ -12,6 +12,7 @@ import no.nav.foreldrepenger.fpformidling.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.fpformidling.inntektarbeidytelse.Inntektsmelding;
 import no.nav.foreldrepenger.fpformidling.inntektarbeidytelse.Inntektsmeldinger;
 import no.nav.foreldrepenger.fpformidling.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.fpformidling.uttak.svp.PeriodeIkkeOppfyltÅrsak;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttakResultatArbeidsforhold;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttakResultatPeriode;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttaksresultat;
@@ -39,11 +40,10 @@ public final class SvpMapperUtil {
         return minsteDatoFraÅvslåttUttak.isPresent() ? minsteDatoFraÅvslåttUttak : finnMinsteFraDatoFraInnvilgetUttak(perioder);
     }
 
-//Henter ut alle avslåtte perioder her fordi det kan være en ferie midt i perioden som tidligere har blitt avslått(8311), men som ikke er en opphørsavslagsgrunn.
-// Siste opphørsdato vil da se merkelig ut siden bruker ikke får svp penger i den avslåtte perioden
     private static Optional<LocalDate> finnMinsteFraDatoAvslåttUttak(List<SvpUttakResultatPeriode> uttaksperioder) {
         return uttaksperioder.stream()
                 .filter(p-> PeriodeResultatType.AVSLÅTT.equals(p.getPeriodeResultatType()))
+                .filter(ur -> PeriodeIkkeOppfyltÅrsak.opphørsAvslagÅrsaker().contains(ur.getPeriodeIkkeOppfyltÅrsak()))
                 .map(p -> p.getTidsperiode().getFomDato())
                 .min(LocalDate::compareTo);
     }

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphørsvp/OpphørPeriodeMapper.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphørsvp/OpphørPeriodeMapper.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.mapper.opphørsvp;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -86,7 +87,7 @@ public class OpphørPeriodeMapper {
                 .collect(Collectors.toList());
 
         if (!opphørtePerioder.isEmpty()) {
-            PeriodeIkkeOppfyltÅrsak årsak = finnPeriodeIkkeOppfyltÅrsak(opphørtePerioder);
+            PeriodeIkkeOppfyltÅrsak årsak = finnNyestePeriodeIkkeOppfyltÅrsak(opphørtePerioder);
             if (årsak != null) {
                 lovReferanser.add(årsak.getLovHjemmelData());
                 return mapOpphørtPeriode(tilkjentYtelsePerioder, uttakResultatArbeidsforhold, språkKode, årsak.getKode(), iay);
@@ -95,8 +96,10 @@ public class OpphørPeriodeMapper {
         return null;
     }
 
-    private static PeriodeIkkeOppfyltÅrsak finnPeriodeIkkeOppfyltÅrsak(List<SvpUttakResultatPeriode> opphørtePerioder) {
-        return opphørtePerioder.stream().map(SvpUttakResultatPeriode::getPeriodeIkkeOppfyltÅrsak).findFirst().orElse(null);
+    private static PeriodeIkkeOppfyltÅrsak finnNyestePeriodeIkkeOppfyltÅrsak(List<SvpUttakResultatPeriode> opphørtePerioder) {
+        return opphørtePerioder.stream()
+                .max(Comparator.comparing(SvpUttakResultatPeriode::getTidsperiode))
+                .map(SvpUttakResultatPeriode::getPeriodeIkkeOppfyltÅrsak).orElse(null);
     }
 
     private static OpphørPeriode mapOpphørtPeriode(List<TilkjentYtelsePeriode> tilkjentYtelse, List<SvpUttakResultatArbeidsforhold> uttakResultatArbeidsforhold, Språkkode språkkode, String opphørÅrsak, Inntektsmeldinger iay) {


### PR DESCRIPTION
…hørte uttaksperioder. Har også lagt inn en sjekk på at vi henter den nyeste opphørsårsaken fra opphørt uttaksperioder. At det finnes flere opphørårsaker vil kun eksistere i unntakstilfeller.