### PR TITLE
TFP-4967 Bruker en unik referanse ved journalføring.

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/BrevTaskProperties.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/BrevTaskProperties.java
@@ -5,6 +5,7 @@ import no.nav.vedtak.felles.prosesstask.api.CommonTaskProperties;
 public final class BrevTaskProperties {
     public static final String HENDELSE_ID = "hendelseId";
     public static final String BESTILLING_UUID = "bestillingUuid";
+    public static final String BESTILLING_ID = "bestillingId";
     public static final String BEHANDLING_UUID = CommonTaskProperties.BEHANDLING_UUID;
     public static final String JOURNALPOST_ID = "journalpostId";
     public static final String SAKSNUMMER = CommonTaskProperties.SAKSNUMMER;

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/DistribuerBrevTask.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/DistribuerBrevTask.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.task;
 
-import java.util.UUID;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -25,7 +25,7 @@ public class DistribuerBrevTask implements ProsessTaskHandler {
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
         JournalpostId journalpostId = new JournalpostId(prosessTaskData.getPropertyValue(BrevTaskProperties.JOURNALPOST_ID));
-        var bestillingUuid = prosessTaskData.getPropertyValue(BrevTaskProperties.BESTILLING_UUID);
-        dokdist.distribuerJournalpost(journalpostId, UUID.fromString(bestillingUuid));
+        var bestillingId = Optional.ofNullable(prosessTaskData.getPropertyValue(BrevTaskProperties.BESTILLING_ID)).orElse(prosessTaskData.getPropertyValue(BrevTaskProperties.BESTILLING_UUID));
+        dokdist.distribuerJournalpost(journalpostId, bestillingId);
     }
 }

--- a/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/Dokdist.java
+++ b/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/Dokdist.java
@@ -1,11 +1,9 @@
 package no.nav.foreldrepenger.fpformidling.integrasjon.dokdist;
 
-import java.util.UUID;
-
 import no.nav.foreldrepenger.fpformidling.typer.JournalpostId;
 
 public interface Dokdist {
 
-    void distribuerJournalpost(JournalpostId journalpostId, UUID bestillingUuid);
+    void distribuerJournalpost(JournalpostId journalpostId, String bestillingId);
 
 }

--- a/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
+++ b/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.fpformidling.integrasjon.dokdist;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -39,8 +38,8 @@ public class DokdistRestKlient implements Dokdist {
     }
 
     @Override
-    public void distribuerJournalpost(JournalpostId journalpostId, UUID bestillingUuid) {
-        DistribuerJournalpostRequest request = lagRequest(journalpostId, bestillingUuid);
+    public void distribuerJournalpost(JournalpostId journalpostId, String bestillingId) {
+        DistribuerJournalpostRequest request = lagRequest(journalpostId, bestillingId);
         try {
             URIBuilder uriBuilder = new URIBuilder(endpointDokdistRestBase + "/distribuerjournalpost");
             Optional<DistribuerJournalpostResponse> response = oidcRestClient.postReturnsOptional(uriBuilder.build(), request,
@@ -55,8 +54,8 @@ public class DokdistRestKlient implements Dokdist {
         }
     }
 
-    private DistribuerJournalpostRequest lagRequest(JournalpostId journalpostId, UUID bestillingUuid) {
-        LOGGER.info("Bestiller distribusjon av {} med batchId {}", journalpostId, bestillingUuid);
-        return new DistribuerJournalpostRequest(journalpostId.getVerdi(), String.valueOf(bestillingUuid), Fagsystem.FPSAK.getOffisiellKode(), Fagsystem.FPSAK.getKode());
+    private DistribuerJournalpostRequest lagRequest(JournalpostId journalpostId, String bestillingId) {
+        LOGGER.info("Bestiller distribusjon av {} med batchId {}", journalpostId, bestillingId);
+        return new DistribuerJournalpostRequest(journalpostId.getVerdi(),  bestillingId, Fagsystem.FPSAK.getOffisiellKode(), Fagsystem.FPSAK.getKode());
     }
 }

--- a/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/JerseyDokdistKlient.java
+++ b/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/JerseyDokdistKlient.java
@@ -6,7 +6,6 @@ import static no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.Fagsystem.FP
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.UUID;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
@@ -38,12 +37,12 @@ public class JerseyDokdistKlient extends AbstractJerseyOidcRestClient implements
     }
 
     @Override
-    public void distribuerJournalpost(JournalpostId id, UUID bestillingUuid) {
+    public void distribuerJournalpost(JournalpostId id, String bestillingId) {
         LOG.trace("Distribuerer journalpost {} til {}", id, target.getUri());
         Optional.ofNullable(
                 invoke(target
                         .request(APPLICATION_JSON_TYPE)
-                        .buildPost(json(new DistribuerJournalpostRequest(id, FPSAK, bestillingUuid))), DistribuerJournalpostResponse.class))
+                        .buildPost(json(new DistribuerJournalpostRequest(id, FPSAK, bestillingId))), DistribuerJournalpostResponse.class))
                 .ifPresentOrElse(v -> LOG.info("Distribuert {} med bestillingsId {}", id, v.getBestillingsId()),
                         () -> { throw new TekniskException("FPFORMIDLING-647352", String.format("Fikk tomt svar ved kall til dokdist for %s.", id)); });
         LOG.info("Distribuerert journalpost {} til {} OK", id, target.getUri());

--- a/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/dto/DistribuerJournalpostRequest.java
+++ b/integrasjon/dokdist/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/dto/DistribuerJournalpostRequest.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.fpformidling.integrasjon.dokdist.dto;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -35,8 +33,8 @@ public class DistribuerJournalpostRequest {
         this.dokumentProdApp = dokumentProdApp;
     }
 
-    public DistribuerJournalpostRequest(JournalpostId id, Fagsystem fagsystem, UUID bestillingUuid) {
-        this(id.getVerdi(), String.valueOf(bestillingUuid), fagsystem.getOffisiellKode(), fagsystem.getKode());
+    public DistribuerJournalpostRequest(JournalpostId id, Fagsystem fagsystem, String bestillingId) {
+        this(id.getVerdi(), bestillingId, fagsystem.getOffisiellKode(), fagsystem.getKode());
     }
 
     public String getJournalpostId() {

--- a/integrasjon/dokdist/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlientTest.java
+++ b/integrasjon/dokdist/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlientTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ public class DokdistRestKlientTest {
                 eq(DistribuerJournalpostResponse.class))).thenReturn(Optional.of(response));
 
         // Act
-        dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, UUID.randomUUID());
+        dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, "12345");
 
         // Assert
         assertThat(uriCaptor.getValue().toURL().toString()).isEqualTo(BASE_URL + "/distribuerjournalpost");
@@ -64,6 +63,6 @@ public class DokdistRestKlientTest {
                 eq(DistribuerJournalpostResponse.class))).thenReturn(Optional.empty());
 
         // Act
-        assertThrows(VLException.class, () -> dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, UUID.randomUUID()));
+        assertThrows(VLException.class, () -> dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, "12345"));
     }
 }

--- a/integrasjon/journal/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/OpprettJournalpostTjeneste.java
+++ b/integrasjon/journal/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/OpprettJournalpostTjeneste.java
@@ -26,6 +26,7 @@ import no.nav.foreldrepenger.fpformidling.typer.Saksnummer;
 import no.nav.vedtak.exception.TekniskException;
 
 @ApplicationScoped
+@SuppressWarnings("java:S107")
 public class OpprettJournalpostTjeneste {
     private static final Logger LOG = LoggerFactory.getLogger(OpprettJournalpostTjeneste.class);
     private Journalpost journalpostRestKlient;
@@ -43,12 +44,12 @@ public class OpprettJournalpostTjeneste {
     }
 
     public OpprettJournalpostResponse journalførUtsendelse(byte[] brev, DokumentMalType dokumentMalType, DokumentFelles dokumentFelles,
-                                                           DokumentHendelse dokumentHendelse, Saksnummer saksnummer, boolean ferdigstill, String overskriftVedFritekstBrev) {
+                                                           DokumentHendelse dokumentHendelse, Saksnummer saksnummer, boolean ferdigstill, String overskriftVedFritekstBrev, String unikReferanse) {
         LOG.info("Starter journalføring av brev for behandling {} med malkode {}", dokumentHendelse.getBehandlingUuid(), dokumentMalType.getKode());
 
         try {
             OpprettJournalpostResponse response = journalpostRestKlient
-                    .opprettJournalpost(lagRequest(brev, dokumentMalType, dokumentFelles, dokumentHendelse, saksnummer, ferdigstill, overskriftVedFritekstBrev), ferdigstill);
+                    .opprettJournalpost(lagRequest(brev, dokumentMalType, dokumentFelles, dokumentHendelse, saksnummer, ferdigstill, overskriftVedFritekstBrev, unikReferanse), ferdigstill);
 
             if (ferdigstill && !response.erFerdigstilt()) {
                 LOG.warn("Journalpost {} ble ikke ferdigstilt", response.getJournalpostId());
@@ -64,7 +65,7 @@ public class OpprettJournalpostTjeneste {
     }
 
     private OpprettJournalpostRequest lagRequest(byte[] brev, DokumentMalType dokumentMalType, DokumentFelles dokumentFelles,
-            DokumentHendelse dokumentHendelse, Saksnummer saksnummer, boolean ferdigstill, String overskriftVedFritekstbrev) {
+            DokumentHendelse dokumentHendelse, Saksnummer saksnummer, boolean ferdigstill, String overskriftVedFritekstbrev, String bestillingsUidMedUnikReferanse) {
         DokumentOpprettRequest dokument = new DokumentOpprettRequest(getTittel(dokumentHendelse, dokumentMalType, overskriftVedFritekstbrev), dokumentMalType.getKode(), null,
                 brev);
 
@@ -82,7 +83,7 @@ public class OpprettJournalpostTjeneste {
                 lagSak(saksnummer),
                 List.of(dokument));
 
-        journalpostRequest.setEksternReferanseId(String.valueOf(dokumentHendelse.getBestillingUuid()));
+        journalpostRequest.setEksternReferanseId(bestillingsUidMedUnikReferanse);
         return journalpostRequest;
     }
 

--- a/integrasjon/journal/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/OpprettJournalpostTjenesteTest.java
+++ b/integrasjon/journal/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/OpprettJournalpostTjenesteTest.java
@@ -56,11 +56,13 @@ public class OpprettJournalpostTjenesteTest {
                 .medTittel("Innvilget Engangsstønad")
                 .build();
 
+        var unikBestillingsId = dokumentHendelse.getBestillingUuid().toString() + "-" + 1;
+
         Saksnummer saksnummer = new Saksnummer("153456789");
 
         // Act
         OpprettJournalpostResponse responseMocked = opprettJournalpost.journalførUtsendelse(GEN_BREV, DokumentMalType.ENGANGSSTØNAD_INNVILGELSE,
-                dokumentFelles, dokumentHendelse, saksnummer, true, null);
+                dokumentFelles, dokumentHendelse, saksnummer, true, null, unikBestillingsId);
 
         // Assert
         Mockito.verify(journalpostRestKlient).opprettJournalpost(requestCaptor.capture(), eq(true));
@@ -76,7 +78,7 @@ public class OpprettJournalpostTjenesteTest {
         assertThat(genRequest.getAvsenderMottaker().idType()).isEqualByComparingTo(AvsenderMottakerIdType.FNR);
         assertThat(genRequest.getJournalfoerendeEnhet()).isEqualTo("9999");
         assertThat(genRequest.getBruker().id()).isEqualTo(FNR);
-        assertThat(genRequest.getEksternReferanseId()).isEqualTo(dokumentHendelse.getBestillingUuid().toString());
+        assertThat(genRequest.getEksternReferanseId()).isEqualTo(unikBestillingsId);
         assertThat(genRequest.getDokumenter().get(0).getBrevkode()).isEqualTo(DokumentMalType.ENGANGSSTØNAD_INNVILGELSE.getKode());
         byte[] brev = genRequest.getDokumenter().get(0).getDokumentvarianter().get(0).getFysiskDokument();
         assertThat(brev).contains(GEN_BREV);


### PR DESCRIPTION
Rettet at det ble journalført dokument med samme bestillingsUuid (ved verge). Dette førte til at en av dokumentene som ble sendt ut (enten til verge eller søker) ikke ble journalført, men brev ble distribuert. Pga spesialhåndtering av journalføring i fpfordel fanger vi ikke opp når journalføring sender 409 - conflict.