### PR TITLE
Håndtere 409 fra dokdist når journalpost allerede er distribuert

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/DistribuerBrevTask.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/task/DistribuerBrevTask.java
@@ -18,7 +18,7 @@ public class DistribuerBrevTask implements ProsessTaskHandler {
     private Dokdist dokdist;
 
     @Inject
-    public DistribuerBrevTask(/* @Jersey */Dokdist dokdist) {
+    public DistribuerBrevTask(Dokdist dokdist) {
         this.dokdist = dokdist;
     }
 

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.fpformidling.integrasjon.dokdist;
 
-import java.util.Optional;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -18,11 +16,8 @@ import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
 
 @Dependent
-@Deprecated
 /**
  *
- * @see JerseyDokdistKlient
- * @deprecated
  */
 public class DokdistRestKlient implements Dokdist {
     private static final Logger LOGGER = LoggerFactory.getLogger(DokdistRestKlient.class);
@@ -42,13 +37,9 @@ public class DokdistRestKlient implements Dokdist {
         DistribuerJournalpostRequest request = lagRequest(journalpostId, bestillingId);
         try {
             URIBuilder uriBuilder = new URIBuilder(endpointDokdistRestBase + "/distribuerjournalpost");
-            Optional<DistribuerJournalpostResponse> response = oidcRestClient.postReturnsOptional(uriBuilder.build(), request,
+            var response = oidcRestClient.postAcceptConflict(uriBuilder.build(), request,
                     DistribuerJournalpostResponse.class);
-            if (response.isPresent()) {
-                LOGGER.info("Distribuert {} med bestillingsId {}", journalpostId, response);
-            } else {
-                throw new TekniskException("FPFORMIDLING-647352", String.format("Fikk tomt svar ved kall til dokdist for %s.", journalpostId));
-            }
+            LOGGER.info("Distribuert {} med bestillingsId {}", journalpostId, response);
         } catch (Exception e) {
             throw new TekniskException("FPFORMIDLING-647353", String.format("Fikk feil ved kall til dokdist for %s.", journalpostId), e);
         }

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlientTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlientTest.java
@@ -1,14 +1,11 @@
 package no.nav.foreldrepenger.fpformidling.integrasjon.dokdist;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +15,6 @@ import no.nav.foreldrepenger.fpformidling.integrasjon.dokdist.dto.DistribuerJour
 import no.nav.foreldrepenger.fpformidling.integrasjon.dokdist.dto.DistribuerJournalpostResponse;
 import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.Fagsystem;
 import no.nav.foreldrepenger.fpformidling.typer.JournalpostId;
-import no.nav.vedtak.exception.VLException;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
 
 public class DokdistRestKlientTest {
@@ -42,8 +38,8 @@ public class DokdistRestKlientTest {
         ArgumentCaptor<DistribuerJournalpostRequest> requestCaptor = ArgumentCaptor.forClass(
                 DistribuerJournalpostRequest.class);
         DistribuerJournalpostResponse response = new DistribuerJournalpostResponse("123");
-        when(oidcRestClient.postReturnsOptional(uriCaptor.capture(), requestCaptor.capture(),
-                eq(DistribuerJournalpostResponse.class))).thenReturn(Optional.of(response));
+        when(oidcRestClient.postAcceptConflict(uriCaptor.capture(), requestCaptor.capture(),
+                eq(DistribuerJournalpostResponse.class))).thenReturn(response);
 
         // Act
         dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, "12345");
@@ -56,13 +52,4 @@ public class DokdistRestKlientTest {
         assertThat(requestCaptor.getValue().getDokumentProdApp()).isEqualTo(Fagsystem.FPSAK.getKode());
     }
 
-    @Test
-    public void skal_kaste_exception_hvis_svaret_er_tomt() {
-        // Arrange
-        when(oidcRestClient.postReturnsOptional(any(URI.class), any(DistribuerJournalpostRequest.class),
-                eq(DistribuerJournalpostResponse.class))).thenReturn(Optional.empty());
-
-        // Act
-        assertThrows(VLException.class, () -> dokdistRestKlient.distribuerJournalpost(JOURNALPOST_ID, "12345"));
-    }
 }


### PR DESCRIPTION
Ref prosesstask nnn og callId CallId_1654407000343_901445469 : - har sjekket saken i GUI og dokumentet dukker opp

Loggmelding "Journalpost med journalpostId=568267060 og bestillingsId=bbdb65fc-4c10-4660-b980-935db150b1fc er allerede distribuert" 

Dette betyr at det kommer en 409/Conflict tilbake og svaret inneholder et fullt objekt, vel bare en bestillingId
Denne endringen godtar svaret og avslutter task -> får sendt kvittering tilbake til fpsak.

Har @mrsladek fiks på disse to Warningene som dokdist logger mange av ?
* distribusjonstidspunkt er ikke satt for journalpost=NNNN, bestillende fagsystem=FS36, dokprodapp=FPSAK
* distribusjonstype er ikke satt for journalpost=NNNN, bestillende fagsystem=FS36, dokprodapp=FPSAK
