### PR TITLE
TFP-5250 Håndtere 410-respons

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/JavaDokdistRestKlient.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/JavaDokdistRestKlient.java
@@ -53,6 +53,8 @@ class JavaDokdistRestKlient extends JavaHttpKlient implements Dokdist {
             return consumeError(response, journalpostId);
         } else if (response.statusCode() == HttpURLConnection.HTTP_CONFLICT) {
             return getResultFunction(journalpostId).apply(response);
+        } else if (response.statusCode() == HttpURLConnection.HTTP_GONE) {
+            return Resultat.MANGLER_ADRESSE;
         }
         return handleResponse(response, getResultFunction(journalpostId));
     }


### PR DESCRIPTION
Fører til at det blir Gosys-oppgave dersom dokdistfordeling sier 410 GONE for bruker som er død og det mangler dødsboadresse - noe som kan ta tid om gjenlevende sitter i uskiftet bo