### PR TITLE
Forenkler jetty oppsett. Fikser jar scanning lokalt.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,15 +6,24 @@ end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true
-max_line_length = 135
+max_line_length = 150
 tab_width = 4
 trim_trailing_whitespace = true
-ij_continuation_indent_size = 8
+ij_continuation_indent_size = 4
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
 ij_formatter_tags_enabled = false
 ij_smart_tabs = false
 ij_wrap_on_typing = false
+
+[*.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
 
 [*.java]
 ij_java_align_consecutive_assignments = false
@@ -263,3 +272,8 @@ ij_java_while_on_new_line = false
 ij_java_wrap_comments = false
 ij_java_wrap_first_method_in_call_chain = false
 ij_java_wrap_long_lines = false
+
+[pom.xml]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>0.4.1</version>
+        <version>0.4.2</version>
     </parent>
 
     <groupId>no.nav.foreldrepenger.fpformidling</groupId>
@@ -29,10 +29,10 @@
         <sonar.projectKey>navikt_fp-formidling</sonar.projectKey>
 
         <!-- Felles artefakter -->
-        <felles.version>4.2.22</felles.version>
+        <felles.version>4.2.23</felles.version>
         <prosesstask.version>3.1.17</prosesstask.version>
-        <kontrakter.version>6.2.8</kontrakter.version>
-        <konfig.version>1.1.5</konfig.version>
+        <kontrakter.version>6.2.9</kontrakter.version>
+        <konfig.version>1.1.7</konfig.version>
 
         <!-- Eksterne -->
         <handlebars.version>4.3.1</handlebars.version>
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>0.4.1</version>
+                <version>0.4.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -115,33 +115,29 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>report-aggregate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
+
+    <!-- Kan slettes etter bom 0.4.3 -->
+    <profiles>
+        <profile>
+            <id>sonar</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <scm>
         <connection>scm:git:https://github.com/navikt/fp-formidling.git</connection>

--- a/web/src/main/java/no/nav/foreldrepenger/fpformidling/web/app/tjenester/ApplicationServiceStarterImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/fpformidling/web/app/tjenester/ApplicationServiceStarterImpl.java
@@ -53,7 +53,7 @@ public class ApplicationServiceStarterImpl implements ApplicationServiceStarter 
                 .map(h -> CompletableFuture.runAsync(() -> {
                     LOG.info("Stopper service {}", h.getClass().getSimpleName());
                     h.stop();
-                })).collect(toList());
+                })).toList();
 
         CompletableFuture.allOf(appHandlers.toArray(new CompletableFuture[appHandlers.size()])).join();
         LOG.info("Stoppet {} services", handlers.size());


### PR DESCRIPTION
WEBINF_JAR_PATTERN pattern skanning vil ikke virker siden vi ikke benytter oss av WEB-INF/lib mappa
updateMetaData(...) er bare en hack til å få ting til å virke, og ideelt sett bør container skann finne ApplicationPath, WebListener, WebServlet og andre annotasjoner.
Det virker med CONTAINER_JAR_PATTERN som skanner gjennom java.class.path også og finner jar filer både ved lokalt kjøring og i docker.