### PR TITLE
Teamdokumenthandtering url oppdatering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,5 @@ jobs:
       image: ghcr.io/${{ github.repository }}:${{ needs.build-app.outputs.build-version }}
       cluster: prod-fss
     secrets: inherit
+    
+    

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/DokArkivKlient.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/journal/DokArkivKlient.java
@@ -7,7 +7,7 @@ import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 @Dependent
-@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "journalpost.rest.v1.url", endpointDefault = "http://dokarkiv.default/rest/journalpostapi/v1/journalpost")
+@RestClientConfig(tokenConfig = TokenFlow.STS_CC, endpointProperty = "journalpost.rest.v1.url", endpointDefault = "http://dokarkiv.teamdokumenthandtering/rest/journalpostapi/v1/journalpost")
 public class DokArkivKlient extends AbstractDokArkivKlient {
 
     public static final String AUTOMATISK_JOURNALFØRENDE_ENHET = "9999";


### PR DESCRIPTION
I NAIS sitt Kubernetes miljø ble det innført overgang fra standard namespace "default" til team namespace "team". Denne endringen påvirket også URL-ene for Kubernetes-tjenesteoppdagelse. Det ble slutt på oppretting av ressurser i default namespace den 29. september 2021.

Tidligere var en vanlig NAIS tjenesteoppdagelses-URL i Kubernetes som følger: "http://app.default/". Her refererte "default" til standardnavneområdet der tjenesten var plassert. Men nå, med innføringen av teamnavneområder, har URL-en blitt endret til "http://app.team/". Dette betyr at "team" erstatter "default" i URL-en og representerer det tilhørende teamet eller prosjektet som tjenesten tilhører.

For å lette denne overgangen ble det manuelt opprettet service redirects i default namespacet.

Vi ser at appen deres har en referanse til en av teamdokumenthandtering sine redirect service adresser. Denne patchen tar ned risiko for at dette skal feile i produksjon ved misforståelser, opprydding eller annet i default namespace til NAIS clusteret.