### PR TITLE
TFP-5487 Forsøker å utlede riktig opphørsdato for svp opphørsbrev

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/SvangerskapspengerAvslagDokumentdataMapper.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/SvangerskapspengerAvslagDokumentdataMapper.java
@@ -88,7 +88,7 @@ public class SvangerskapspengerAvslagDokumentdataMapper implements DokumentdataM
 
         mapÅrsakOgLovhjemmel(behandlingsresultat.getAvslagsårsak(), uttaksperioder, dokumentdataBuilder, behandling.getUuid());
 
-        SvpMapperUtil.finnFørsteUttakssdato(uttaksperioder, behandling.getBehandlingsresultat())
+        SvpMapperUtil.finnFørsteAvslåtteUttakDato(uttaksperioder, behandling.getBehandlingsresultat())
             .ifPresent(d -> dokumentdataBuilder.medStønadsdatoFom(formaterDato(d, språkkode)));
 
 

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.mapper.felles;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -9,8 +10,8 @@ import no.nav.foreldrepenger.fpformidling.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.fpformidling.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.fpformidling.inntektarbeidytelse.Inntektsmelding;
 import no.nav.foreldrepenger.fpformidling.inntektarbeidytelse.Inntektsmeldinger;
+import no.nav.foreldrepenger.fpformidling.tilkjentytelse.TilkjentYtelsePeriode;
 import no.nav.foreldrepenger.fpformidling.uttak.PeriodeResultatType;
-import no.nav.foreldrepenger.fpformidling.uttak.svp.PeriodeIkkeOppfyltÅrsak;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvangerskapspengerUttak;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttakResultatArbeidsforhold;
 import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttakResultatPeriode;
@@ -35,20 +36,18 @@ public final class SvpMapperUtil {
         return vilkårTyper.stream().map(vt -> vt.getLovReferanse(FagsakYtelseType.SVANGERSKAPSPENGER)).findFirst().orElse("");
     }
 
-    public static Optional<LocalDate> finnFørsteUttakssdato(List<SvpUttakResultatPeriode> uttaksperioder, Behandlingsresultat behandlingsresultat) {
-        return finnMinsteDatoFraUttak(uttaksperioder).or(behandlingsresultat::getSkjæringstidspunkt);
+    public static Optional<LocalDate> finnFørsteAvslåtteUttakDato(List<SvpUttakResultatPeriode> uttaksperioder, Behandlingsresultat behandlingsresultat) {
+        return finnMinsteDatoFraAvslåttUttak(uttaksperioder).or(behandlingsresultat::getSkjæringstidspunkt);
 
     }
 
-    public static Optional<LocalDate> finnMinsteDatoFraUttak(List<SvpUttakResultatPeriode> perioder) {
-        var minsteDatoFraÅvslåttUttak = finnMinsteFraDatoAvslåttUttak(perioder);
-        return minsteDatoFraÅvslåttUttak.isPresent() ? minsteDatoFraÅvslåttUttak : finnMinsteFraDatoFraInnvilgetUttak(perioder);
+    public static Optional<LocalDate> finnMinsteDatoFraAvslåttUttak(List<SvpUttakResultatPeriode> perioder) {
+        return finnMinsteFraDatoAvslåttUttak(perioder).or(() ->finnMinsteFraDatoFraInnvilgetUttak(perioder));
     }
 
     private static Optional<LocalDate> finnMinsteFraDatoAvslåttUttak(List<SvpUttakResultatPeriode> uttaksperioder) {
         return uttaksperioder.stream()
             .filter(p -> PeriodeResultatType.AVSLÅTT.equals(p.getPeriodeResultatType()))
-            .filter(ur -> PeriodeIkkeOppfyltÅrsak.opphørsAvslagÅrsaker().contains(ur.getPeriodeIkkeOppfyltÅrsak()))
             .map(p -> p.getTidsperiode().getFomDato())
             .min(LocalDate::compareTo);
     }
@@ -74,4 +73,29 @@ public final class SvpMapperUtil {
         }
         return antallArbeidsgivere;
     }
+
+    public static Optional<LocalDate> finnOpphørsdato(List<TilkjentYtelsePeriode> tilkjentYtelsePerioder) {
+        return  tilkjentYtelsePerioder.stream()
+            .filter(tilkjentYtelsePeriode -> tilkjentYtelsePeriode.getDagsats() > 0)
+            .map(TilkjentYtelsePeriode::getPeriodeTom)
+            .max(LocalDate::compareTo)
+            .map(localDate -> justerForHelg(localDate.plusDays(1)));
+    }
+
+    public static LocalDate justerForHelg(LocalDate date) {
+        if (erLørdag(date)) {
+            return date.plusDays(2);
+        } else if (erSøndag(date)) {
+            return date.plusDays(1);
+        } else
+            return date;
+    }
+    private static boolean erLørdag(LocalDate date) {
+        return date.getDayOfWeek().equals(DayOfWeek.SATURDAY);
+    }
+
+    private static boolean erSøndag(LocalDate date) {
+        return date.getDayOfWeek().equals(DayOfWeek.SUNDAY);
+    }
+
 }

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtil.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import no.nav.foreldrepenger.fpformidling.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.fpformidling.fagsak.FagsakYtelseType;
@@ -18,7 +19,11 @@ import no.nav.foreldrepenger.fpformidling.uttak.svp.SvpUttakResultatPeriode;
 import no.nav.foreldrepenger.fpformidling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.fpformidling.vilkår.VilkårType;
 
+import static java.time.temporal.TemporalAdjusters.next;
+
 public final class SvpMapperUtil {
+
+    private static final Set WEEKEND = Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
 
     private SvpMapperUtil() {
     }
@@ -83,19 +88,6 @@ public final class SvpMapperUtil {
     }
 
     public static LocalDate justerForHelg(LocalDate date) {
-        if (erLørdag(date)) {
-            return date.plusDays(2);
-        } else if (erSøndag(date)) {
-            return date.plusDays(1);
-        } else
-            return date;
+        return WEEKEND.contains(DayOfWeek.from(date)) ? date.with(next(DayOfWeek.MONDAY)) : date;
     }
-    private static boolean erLørdag(LocalDate date) {
-        return date.getDayOfWeek().equals(DayOfWeek.SATURDAY);
-    }
-
-    private static boolean erSøndag(LocalDate date) {
-        return date.getDayOfWeek().equals(DayOfWeek.SUNDAY);
-    }
-
 }

--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphorsvp/SvangerskapspengerOpphørDokumentdataMapper.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphorsvp/SvangerskapspengerOpphørDokumentdataMapper.java
@@ -69,8 +69,6 @@ public class SvangerskapspengerOpphørDokumentdataMapper implements Dokumentdata
         fellesBuilder.medBrevDato(dokumentFelles.getDokumentDato() != null ? formaterDato(dokumentFelles.getDokumentDato(), språkkode) : null);
         fellesBuilder.medErAutomatiskBehandlet(dokumentFelles.getAutomatiskBehandlet());
 
-        var uttaksperioder = SvpMapperUtil.hentUttaksperioder(svpUttaksresultat);
-
         var dokumentdatabuilder = SvangerskapspengerOpphørDokumentdata.ny()
             .medFelles(fellesBuilder.build())
             .medHalvG(BeregningsgrunnlagMapper.getHalvGOrElseZero(beregningsgrunnlag))
@@ -81,8 +79,9 @@ public class SvangerskapspengerOpphørDokumentdataMapper implements Dokumentdata
             svpUttaksresultat.map(SvangerskapspengerUttak::getUttakResultatArbeidsforhold).orElse(Collections.emptyList()), språkkode, iay,
             tilkjentYtelsePerioder);
 
-        SvpMapperUtil.finnFørsteUttakssdato(uttaksperioder, behandling.getBehandlingsresultat())
-            .ifPresent(d -> dokumentdatabuilder.medOpphørsdato(formaterDato(d, språkkode)));
+        var opphørsdato = SvpMapperUtil.finnOpphørsdato(tilkjentYtelsePerioder).or(() -> behandling.getBehandlingsresultat().getSkjæringstidspunkt());
+
+        opphørsdato.ifPresent(d -> dokumentdatabuilder.medOpphørsdato(formaterDato(d, språkkode)));
 
         familieHendelse.dødsdato().ifPresent(d -> dokumentdatabuilder.medDødsdatoBarn(formaterDato(d, språkkode)));
 

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtilTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/felles/SvpMapperUtilTest.java
@@ -1,0 +1,73 @@
+package no.nav.foreldrepenger.fpformidling.brevproduksjon.mapper.felles;
+
+import static java.util.List.of;
+import static no.nav.foreldrepenger.fpformidling.typer.DatoIntervall.fraOgMedTilOgMed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.fpformidling.beregningsgrunnlag.AktivitetStatus;
+import no.nav.foreldrepenger.fpformidling.tilkjentytelse.TilkjentYtelseAndel;
+import no.nav.foreldrepenger.fpformidling.tilkjentytelse.TilkjentYtelsePeriode;
+import no.nav.foreldrepenger.fpformidling.virksomhet.Arbeidsgiver;
+
+class SvpMapperUtilTest {
+
+    private final LocalDate tilkjentYtelseFraDato = LocalDate.of(2023, 5, 15);
+    private final LocalDate tilkjentYtelseTilDato = tilkjentYtelseFraDato.plusDays(2);
+    private final LocalDate tilkjentYtelsePeriode2FraDato = tilkjentYtelseFraDato.plusDays(3);
+
+    @Test
+    void finnRiktigOpphørsdatoMedDagsats() {
+        var forventetDato = LocalDate.of(2023, 5, 18);
+
+        List<TilkjentYtelsePeriode> tilkjentYtelseperiodeListe = List.of(opprettTilkjentYtelse(tilkjentYtelseFraDato, tilkjentYtelseTilDato, 500L),
+            opprettTilkjentYtelse(tilkjentYtelsePeriode2FraDato, tilkjentYtelseFraDato.plusDays(6), 0L));
+
+        var opphørsdato = SvpMapperUtil.finnOpphørsdato(tilkjentYtelseperiodeListe);
+
+        assertThat(opphørsdato).isEqualTo(Optional.of(forventetDato));
+    }
+
+    @Test
+    void finnRiktigOpphørsdatoJustertForHelgLørdagOgSøndag() {
+        var forventetDato = LocalDate.of(2023, 5, 22);
+
+        List<TilkjentYtelsePeriode> tilkjentYtelseperiodeListe = List.of(opprettTilkjentYtelse(tilkjentYtelseFraDato, tilkjentYtelseTilDato, 500L),
+            opprettTilkjentYtelse(tilkjentYtelsePeriode2FraDato, tilkjentYtelseFraDato.plusDays(4), 200L));
+
+        var opphørsdato = SvpMapperUtil.finnOpphørsdato(tilkjentYtelseperiodeListe);
+
+        assertThat(opphørsdato).isEqualTo(Optional.of(forventetDato));
+    }
+
+    @Test
+    void finnRiktigOpphørsdatoJustertForHelgSøndag() {
+        var forventetDato = LocalDate.of(2023, 5, 22);
+
+        List<TilkjentYtelsePeriode> tilkjentYtelseperiodeListe = List.of(opprettTilkjentYtelse(tilkjentYtelseFraDato, tilkjentYtelseTilDato, 500L),
+            opprettTilkjentYtelse(tilkjentYtelsePeriode2FraDato, tilkjentYtelseFraDato.plusDays(5), 200L));
+
+        var opphørsdato = SvpMapperUtil.finnOpphørsdato(tilkjentYtelseperiodeListe);
+
+        assertThat(opphørsdato).isEqualTo(Optional.of(forventetDato));
+    }
+
+
+    private TilkjentYtelsePeriode opprettTilkjentYtelse(LocalDate fraDato, LocalDate tilDato, Long dagsats) {
+        return TilkjentYtelsePeriode.ny()
+                .medDagsats(dagsats)
+                .medPeriode(fraOgMedTilOgMed(fraDato, tilDato))
+                .medAndeler(of(TilkjentYtelseAndel.ny()
+                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
+                    .medArbeidsgiver(new Arbeidsgiver("123456", "ARBEIDSGIVER_NAVN"))
+                    .medStillingsprosent(BigDecimal.valueOf(100))
+                    .build()))
+                .build();
+    }
+}

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphorsvp/SvangerskapspengerOpphørDokumentdataMapperTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/mapper/opphorsvp/SvangerskapspengerOpphørDokumentdataMapperTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import no.nav.foreldrepenger.fpformidling.brevproduksjon.mapper.felles.SvpMapperUtil;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -111,7 +113,7 @@ class SvangerskapspengerOpphørDokumentdataMapperTest {
         assertThat(dokumentdata.getFelles().getBehandlesAvKA()).isFalse();
         assertThat(dokumentdata.getFelles().getErUtkast()).isFalse();
 
-        assertThat(dokumentdata.getOpphørsdato()).isEqualTo(formaterDato(PERIODE1_FOM, Språkkode.NB));
+        assertThat(dokumentdata.getOpphørsdato()).isEqualTo(formaterDato(SvpMapperUtil.justerForHelg(PERIODE1_TOM.plusDays(1)), Språkkode.NB));
         assertThat(dokumentdata.getDødsdatoBarn()).isNull();
         assertThat(dokumentdata.getFødselsdato()).isEqualTo(formaterDato(LocalDate.now(), Språkkode.NB));
         assertThat(dokumentdata.getErSøkerDød()).isFalse();


### PR DESCRIPTION
Henter siste dato fra tilkjent ytelse i stdet for fra uttak. Tar kun med de som har dagsat, legger på en dag og justerer eventuelt for helg. Uttak vil kunne inneholde flere opphørsårsaker og da vet vi ikke hvilken fra dato som blir riktig for tilfellet