### PR TITLE
TFP-5536 ForeldrepengerOpphørDokumentdataMapper

### DIFF
--- a/web/src/test/resources/application-vtp.properties
+++ b/web/src/test/resources/application-vtp.properties
@@ -10,7 +10,7 @@ systembruker.password=vtp
 
 ## Sikkerhet
 # Azure
-azure.app.well.known.url=http://authserver:8086/azureAd/.well-known/openid-configuration
+azure.app.well.known.url=http://localhost:8060/rest/azuread/.well-known/openid-configuration
 azure.app.client.id=vtp
 azure.app.client.secret=vtp
 


### PR DESCRIPTION
Endret slik at ved barns død eller bruker er død henter vi siste utbetalingsdato fra siste innvilgede dato i stedet for å utlede dette fra opphørsdato. Dette vil bli feil dersom siste del av uttaket er avslått av endre grunner enn opphør.