### PR TITLE
TFP-5592: Utleder riktig brev type basert på behandling og ikke hende…

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjeneste.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjeneste.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.fpformidling.behandling.Behandling;
 import no.nav.foreldrepenger.fpformidling.brevproduksjon.tjenester.DomeneobjektProvider;
+import no.nav.foreldrepenger.fpformidling.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.fpformidling.hendelser.DokumentHendelse;
 import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.DokumentMalType;
 import no.nav.foreldrepenger.fpformidling.vedtak.Vedtaksbrev;
@@ -38,13 +39,15 @@ public class BrevBestillerTjeneste {
     public void bestillBrev(DokumentHendelse dokumentHendelse) {
         var behandling = hentBehandling(dokumentHendelse);
         var dokumentMal = utledDokumentMal(behandling, dokumentHendelse);
-        var dokumentType = utledDokumentType(dokumentHendelse, behandling, dokumentMal);
+        var dokumentType = utledDokumentType(dokumentHendelse.getYtelseType(), behandling, dokumentMal);
         dokgenBrevproduksjonTjeneste.bestillBrev(dokumentHendelse, behandling, dokumentMal, dokumentType);
     }
 
-    private DokumentMalType utledDokumentType(DokumentHendelse dokumentHendelse, Behandling behandling, DokumentMalType dokumentMal) {
-        return Vedtaksbrev.FRITEKST.equals(dokumentHendelse.getVedtaksbrev()) ? dokumentMalUtleder.utledDokumentType(behandling,
-            dokumentHendelse.getYtelseType()) : dokumentMal;
+    private DokumentMalType utledDokumentType(FagsakYtelseType ytelseType, Behandling behandling, DokumentMalType dokumentMal) {
+        if (DokumentMalType.FRITEKSTBREV.equals(dokumentMal)) {
+            return dokumentMalUtleder.utledDokumentType(behandling, ytelseType);
+        }
+        return dokumentMal;
     }
 
     private Behandling hentBehandling(DokumentHendelse dokumentHendelse) {


### PR DESCRIPTION
…lsestype.

Det var en liten bug i forrige løsning siden hendelsen får ikke noe Brevtype ved bestilling - den kommer kun ved forhåndsvisning. 

Det ble fort synlig i [prometheus](https://prometheus.prod-fss.nav.cloud.nais.io/graph?g0.expr=sum(brev_distribuert_total)%20by%20(malType%2C%20brevType)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=30m) at alle brevene får fortsatt brevtype "FRITEK".

Utvidet testene slikt at det bør være riktig nå.