### PR TITLE
FIX Mapping av Fritekstmal til opprinnelig mal

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjeneste.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjeneste.java
@@ -8,7 +8,6 @@ import no.nav.foreldrepenger.fpformidling.brevproduksjon.tjenester.DomeneobjektP
 import no.nav.foreldrepenger.fpformidling.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.fpformidling.hendelser.DokumentHendelse;
 import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.DokumentMalType;
-import no.nav.foreldrepenger.fpformidling.vedtak.Vedtaksbrev;
 
 @ApplicationScoped
 public class BrevBestillerTjeneste {
@@ -45,7 +44,7 @@ public class BrevBestillerTjeneste {
 
     private DokumentMalType utledDokumentType(FagsakYtelseType ytelseType, Behandling behandling, DokumentMalType dokumentMal) {
         if (DokumentMalType.FRITEKSTBREV.equals(dokumentMal)) {
-            return dokumentMalUtleder.utledDokumentType(behandling, ytelseType);
+            return dokumentMalUtleder.utledDokumentType(behandling, ytelseType, true);
         }
         return dokumentMal;
     }

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjenesteTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/BrevBestillerTjenesteTest.java
@@ -145,7 +145,7 @@ class BrevBestillerTjenesteTest {
         var behandling = mock(Behandling.class);
         when(domeneobjektProvider.hentBehandling(any())).thenReturn(behandling);
         when(dokumentMalUtleder.utledDokumentmal(behandling, dokumentHendelse)).thenReturn(DokumentMalType.FRITEKSTBREV);
-        when(dokumentMalUtleder.utledDokumentType(behandling, dokumentHendelse.getYtelseType())).thenReturn(DokumentMalType.FORELDREPENGER_INNVILGELSE);
+        when(dokumentMalUtleder.utledDokumentType(behandling, dokumentHendelse.getYtelseType(), true)).thenReturn(DokumentMalType.FORELDREPENGER_INNVILGELSE);
 
         var dokgenBrevproduksjonTjeneste = mock(DokgenBrevproduksjonTjeneste.class);
 
@@ -156,7 +156,7 @@ class BrevBestillerTjenesteTest {
 
         // Assert
         verify(dokgenBrevproduksjonTjeneste).bestillBrev(dokumentHendelse, behandling, DokumentMalType.FRITEKSTBREV, DokumentMalType.FORELDREPENGER_INNVILGELSE);
-        verify(dokumentMalUtleder).utledDokumentType(behandling, dokumentHendelse.getYtelseType());
+        verify(dokumentMalUtleder).utledDokumentType(behandling, dokumentHendelse.getYtelseType(), true);
         verify(dokumentMalUtleder).utledDokumentmal(behandling, dokumentHendelse);
 
         verifyNoMoreInteractions(dokumentMalUtleder, dokgenBrevproduksjonTjeneste, domeneobjektProvider);
@@ -180,7 +180,7 @@ class BrevBestillerTjenesteTest {
         // Assert
         verify(dokgenBrevproduksjonTjeneste).bestillBrev(dokumentHendelse, behandling, DokumentMalType.FORELDREPENGER_INNVILGELSE, DokumentMalType.FORELDREPENGER_INNVILGELSE);
         verify(dokumentMalUtleder).utledDokumentmal(behandling, dokumentHendelse);
-        verify(dokumentMalUtleder, never()).utledDokumentType(behandling, dokumentHendelse.getYtelseType());
+        verify(dokumentMalUtleder, never()).utledDokumentType(behandling, dokumentHendelse.getYtelseType(), false);
 
         verifyNoMoreInteractions(dokumentMalUtleder, dokgenBrevproduksjonTjeneste, domeneobjektProvider);
     }
@@ -203,7 +203,7 @@ class BrevBestillerTjenesteTest {
         // Assert
         verify(dokgenBrevproduksjonTjeneste).forhåndsvisBrev(dokumentHendelse, behandling, DokumentMalType.FORELDREPENGER_ANNULLERT);
         verify(dokumentMalUtleder).utledDokumentmal(behandling, dokumentHendelse);
-        verify(dokumentMalUtleder, never()).utledDokumentType(behandling, dokumentHendelse.getYtelseType());
+        verify(dokumentMalUtleder, never()).utledDokumentType(behandling, dokumentHendelse.getYtelseType(), false);
 
         verifyNoMoreInteractions(dokumentMalUtleder, dokgenBrevproduksjonTjeneste, domeneobjektProvider);
     }

--- a/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokumentMalUtlederTest.java
+++ b/brevproduksjon/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokumentMalUtlederTest.java
@@ -1,5 +1,16 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.bestiller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import no.nav.foreldrepenger.fpformidling.behandling.Behandling;
 import no.nav.foreldrepenger.fpformidling.behandling.BehandlingType;
 import no.nav.foreldrepenger.fpformidling.behandling.Behandlingsresultat;
@@ -14,17 +25,6 @@ import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.BehandlingResultatT
 import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.DokumentMalType;
 import no.nav.foreldrepenger.fpformidling.vedtak.Vedtaksbrev;
 import no.nav.vedtak.exception.VLException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class DokumentMalUtlederTest {
 
@@ -214,7 +214,23 @@ class DokumentMalUtlederTest {
                 .build())
             .build();
         assertThat(dokumentMalUtleder.utledDokumentmal(behandling, hendelse).getKode()).isEqualTo(DokumentMalType.FRITEKSTBREV.getKode());
-        assertThat(dokumentMalUtleder.utledDokumentType(behandling, hendelse.getYtelseType()).getKode()).isEqualTo(DokumentMalType.FORELDREPENGER_INNVILGELSE.getKode());
+        assertThat(dokumentMalUtleder.utledDokumentType(behandling, hendelse.getYtelseType(), false).getKode()).isEqualTo(DokumentMalType.FORELDREPENGER_INNVILGELSE.getKode());
+    }
+
+    @Test
+    void utled_riktig_brevtype_ved_fritekst_ogEndringIYtelsen() {
+        hendelse = standardBuilder().medGjelderVedtak(true).build();
+        var behandling = Behandling.builder()
+            .medUuid(UUID.randomUUID())
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .medBehandlingsresultat(Behandlingsresultat.builder()
+                .medVedtaksbrev(Vedtaksbrev.FRITEKST)
+                .medBehandlingResultatType(BehandlingResultatType.FORELDREPENGER_ENDRET)
+                .medKonsekvenserForYtelsen(List.of(KonsekvensForYtelsen.ENDRING_I_FORDELING_AV_YTELSEN))
+                .build())
+            .build();
+        assertThat(dokumentMalUtleder.utledDokumentmal(behandling, hendelse).getKode()).isEqualTo(DokumentMalType.FRITEKSTBREV.getKode());
+        assertThat(dokumentMalUtleder.utledDokumentType(behandling, hendelse.getYtelseType(), true).getKode()).isEqualTo(DokumentMalType.ENDRING_UTBETALING.getKode());
     }
 
     @Test

--- a/domene/src/main/java/no/nav/foreldrepenger/fpformidling/kodeverk/kodeverdi/DokumentMalType.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/fpformidling/kodeverk/kodeverdi/DokumentMalType.java
@@ -35,6 +35,7 @@ public enum DokumentMalType implements Kodeverdi {
     KLAGE_OMGJORT(DokumentMalTypeKode.KLAGE_OMGJORT, "Vedtak om omgjøring av klage"),
     KLAGE_OVERSENDT(DokumentMalTypeKode.KLAGE_OVERSENDT, "Klage oversendt til klageinstans"),
     ETTERLYS_INNTEKTSMELDING(DokumentMalTypeKode.ETTERLYS_INNTEKTSMELDING, "Etterlys inntektsmelding"),
+    ENDRING_UTBETALING(DokumentMalTypeKode.ENDRING_UTBETALING, "Endring av utbetaling av ytelse"),
 
     // Disse brevene er utgåtte, men beholdes her grunnet historisk bruk i databasen:
     @Deprecated FRITEKSTBREV_DOK(DokumentMalTypeKode.FRITEKSTBREV_DOK, "Fritekstbrev"), //NOSONAR

--- a/domene/src/main/java/no/nav/foreldrepenger/fpformidling/kodeverk/kodeverdi/DokumentMalTypeKode.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/fpformidling/kodeverk/kodeverdi/DokumentMalTypeKode.java
@@ -32,6 +32,8 @@ public class DokumentMalTypeKode {
     public static final String KLAGE_STADFESTET = "KGESTA";
     public static final String ETTERLYS_INNTEKTSMELDING = "ELYSIM";
 
+    public static final String ENDRING_UTBETALING = "ENDUTB";
+
     // Disse brevene er utgåtte, men beholdes her grunnet historisk bruk i databasen:
     @Deprecated(forRemoval = true)
     public static final String FRITEKSTBREV_DOK = "FRITKS"; //NOSONAR


### PR DESCRIPTION
Retter at vi ikke har noe å mappe fritekst brev som gjelder vedtak og endring i ytelsen til. I dag har vi ingen mal for denne type av endring. Saksbehandler overstyrer og lager et helt eget brev. Oppretter en malkode som kun benyttes for mapping og når vi lagrer journalposten. Malkoden kan brukes når vi oppretter et brev for denne type endring