### PR TITLE
TFP-4609 Legger til ForvaltningRestTjeneste

### DIFF
--- a/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokgenBrevproduksjonTjeneste.java
+++ b/brevproduksjon/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokgenBrevproduksjonTjeneste.java
@@ -140,10 +140,29 @@ public class DokgenBrevproduksjonTjeneste {
         return brev;
     }
 
+    public String genererJson(DokumentHendelse dokumentHendelse,
+                                   Behandling behandling,
+                                   DokumentMalType dokumentMal,
+                                   BestillingType bestillingType) {
+        var dokumentdataMapper = dokumentdataMapperProvider.getDokumentdataMapper(dokumentMal);
+        var dokumentData = lagDokumentDataFor(behandling, dokumentMal, bestillingType);
+        var dokumentfelles = dokumentData.getFørsteDokumentFelles();
+        var dokumentdata = dokumentdataMapper.mapTilDokumentdata(dokumentfelles, dokumentHendelse, behandling,BestillingType.UTKAST == bestillingType);
+        dokumentfelles.setBrevData(DefaultJsonMapper.toJson(dokumentdata));
+        dokumentdata.getFelles().anonymiser();
+        return DefaultJsonMapper.toJson(dokumentdata);
+    }
+
     private DokumentData lagreDokumentDataFor(Behandling behandling, DokumentMalType dokumentMal, BestillingType bestillingType) {
         var dokumentData = lagDokumentData(behandling, dokumentMal, bestillingType);
         dokumentFellesDataMapper.opprettDokumentDataForBehandling(behandling, dokumentData);
         dokumentRepository.lagre(dokumentData);
+        return dokumentData;
+    }
+
+    private DokumentData lagDokumentDataFor(Behandling behandling, DokumentMalType dokumentMal, BestillingType bestillingType) {
+        var dokumentData = lagDokumentData(behandling, dokumentMal, bestillingType);
+        dokumentFellesDataMapper.opprettDokumentDataForBehandling(behandling, dokumentData);
         return dokumentData;
     }
 


### PR DESCRIPTION
Ny ForvaltningRestTjeneste for å generer brevdata i json format for en behandlingUuid. Det er kun mulig for vedtaksbrev. Tjenesten er ment brukt til feilanalyse  siden vi ikke lenger skal lagre brevdata når brev bestilles.