### PR TITLE
TFP-5668: Tar i bruk V3 kvittering endepunkt som ikke lenger trenger dokument mal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <!-- Felles artefakter -->
         <felles.version>7.0.4</felles.version>
         <prosesstask.version>5.0.4</prosesstask.version>
-        <kontrakter.version>9.0.2</kontrakter.version>
+        <kontrakter.version>9.0.4</kontrakter.version>
 
         <!-- Eksterne -->
         <handlebars.version>4.3.1</handlebars.version>

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokumentMalUtleder.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/bestiller/DokumentMalUtleder.java
@@ -19,9 +19,13 @@ import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.DokumentMalType;
 import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @ApplicationScoped
 class DokumentMalUtleder {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DokumentMalUtleder.class);
     private static final String UTVIKLERFEIL_INGEN_ENDRING_SAMMEN = "Utviklerfeil: Det skal ikke være mulig å ha INGEN_ENDRING sammen med andre konsekvenser. BehandlingUuid: ";
     private DomeneobjektProvider domeneobjektProvider;
     private DokumentHendelseTjeneste dokumentHendelseTjeneste;
@@ -99,6 +103,7 @@ class DokumentMalUtleder {
             return hendelse.getDokumentMalType();
         }
         if (Boolean.TRUE.equals(hendelse.isGjelderVedtak())) {
+            LOG.info("Må utlede mal for hendelse {}", hendelse.getBestillingUuid());
             return utledVedtaksbrev(behandling, hendelse);
         }
         throw ukjentMalException(behandling);

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjeneste.java
@@ -1,10 +1,10 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.tjenester.historikk;
 
+import java.util.UUID;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.Behandlinger;
-import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
 import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 
 @ApplicationScoped
@@ -21,8 +21,8 @@ public class DokumentKvitteringTjeneste {
         this.fpsakKlient = restKlient;
     }
 
-    public void sendKvittering(DokumentKvitteringDto kvittering) {
-        fpsakKlient.kvitterDokument(kvittering);
+    public void sendKvittering(UUID behandlingUuid,  UUID bestillingUuid, String journalpostId, String dokumentId) {
+        fpsakKlient.kvitterDokument(new DokumentKvitteringDto(behandlingUuid, bestillingUuid, journalpostId, dokumentId));
     }
 
 }

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjeneste.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.Behandlinger;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 
 @ApplicationScoped
 public class DokumentKvitteringTjeneste {
@@ -20,7 +21,7 @@ public class DokumentKvitteringTjeneste {
         this.fpsakKlient = restKlient;
     }
 
-    public void sendKvittering(DokumentProdusertDto kvittering) {
+    public void sendKvittering(DokumentKvitteringDto kvittering) {
         fpsakKlient.kvitterDokument(kvittering);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
@@ -30,10 +29,9 @@ public class SendKvitteringTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var kvittering = new DokumentKvitteringDto(prosessTaskData.getBehandlingUuid(),
+        kvitteringTjeneste.sendKvittering(prosessTaskData.getBehandlingUuid(),
             UUID.fromString(prosessTaskData.getPropertyValue(BESTILLING_UUID)),
             prosessTaskData.getPropertyValue(JOURNALPOST_ID),
             prosessTaskData.getPropertyValue(DOKUMENT_ID));
-        kvitteringTjeneste.sendKvittering(kvittering);
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
@@ -1,21 +1,19 @@
 package no.nav.foreldrepenger.fpformidling.brevproduksjon.tjenester.historikk;
 
-import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
-import java.util.UUID;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 
 @ApplicationScoped
 @ProsessTask("formidling.publiserHistorikk")
 public class SendKvitteringTask implements ProsessTaskHandler {
 
     public static final String BESTILLING_UUID = "bestillingUuid";
-    public static final String DOKUMENT_MAL_TYPE = "dokumentMalType";
     public static final String JOURNALPOST_ID = "journalpostId";
     public static final String DOKUMENT_ID = "dokumentId";
 
@@ -32,9 +30,10 @@ public class SendKvitteringTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var kvittering = new DokumentProdusertDto(prosessTaskData.getBehandlingUuid(),
-            UUID.fromString(prosessTaskData.getPropertyValue(BESTILLING_UUID)), prosessTaskData.getPropertyValue(DOKUMENT_MAL_TYPE),
-            prosessTaskData.getPropertyValue(JOURNALPOST_ID), prosessTaskData.getPropertyValue(DOKUMENT_ID));
+        var kvittering = new DokumentKvitteringDto(prosessTaskData.getBehandlingUuid(),
+            UUID.fromString(prosessTaskData.getPropertyValue(BESTILLING_UUID)),
+            prosessTaskData.getPropertyValue(JOURNALPOST_ID),
+            prosessTaskData.getPropertyValue(DOKUMENT_ID));
         kvitteringTjeneste.sendKvittering(kvittering);
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/SendKvitteringTask.java
@@ -19,7 +19,7 @@ public class SendKvitteringTask implements ProsessTaskHandler {
 
     private DokumentKvitteringTjeneste kvitteringTjeneste;
 
-    public SendKvitteringTask() {
+    SendKvitteringTask() {
         //CDI
     }
 

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/fpsak/BehandlingRestKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/fpsak/BehandlingRestKlient.java
@@ -12,6 +12,7 @@ import no.nav.foreldrepenger.fpformidling.domene.behandling.BehandlingRelLinkPay
 import no.nav.foreldrepenger.fpformidling.domene.behandling.BehandlingResourceLink;
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.dto.behandling.BehandlingDto;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
@@ -33,8 +34,8 @@ public class BehandlingRestKlient implements Behandlinger {
     }
 
     @Override
-    public void kvitterDokument(DokumentProdusertDto kvittering) {
-        var request = RestRequest.newPOSTJson(kvittering, toUri(restConfig.fpContextPath(), FPSAK_API, "/brev/kvittering"), restConfig);
+    public void kvitterDokument(DokumentKvitteringDto kvittering) {
+        var request = RestRequest.newPOSTJson(kvittering, toUri(restConfig.fpContextPath(), FPSAK_API, "/brev/kvittering/v3"), restConfig);
         restClient.sendReturnOptional(request, String.class);
     }
 

--- a/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/fpsak/Behandlinger.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/fpsak/Behandlinger.java
@@ -24,7 +24,7 @@ import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.dto.uttak.UttakResul
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.dto.uttak.YtelseFordelingDto;
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.dto.uttak.saldo.SaldoerDto;
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.dto.uttak.svp.SvangerskapspengerUttakResultatDto;
-import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 import no.nav.foreldrepenger.kontrakter.fpsak.beregningsgrunnlag.v2.BeregningsgrunnlagDto;
 import no.nav.foreldrepenger.kontrakter.fpsak.tilkjentytelse.TilkjentYtelseDagytelseDto;
 
@@ -32,7 +32,7 @@ public interface Behandlinger {
 
     <T> Optional<T> hentDtoFraLink(BehandlingResourceLink link, Class<T> clazz);
 
-    void kvitterDokument(DokumentProdusertDto kvittering);
+    void kvitterDokument(DokumentKvitteringDto kvittering);
 
     default BeregningsgrunnlagDto hentBeregningsgrunnlag(List<BehandlingResourceLink> resourceLinker) {
         return hentFormidlingBeregningsgrunnlagHvisFinnes(resourceLinker).orElseThrow(

--- a/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjenesteTest.java
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
 
-import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,8 +14,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.fpformidling.integrasjon.fpsak.Behandlinger;
-import no.nav.foreldrepenger.fpformidling.kodeverk.kodeverdi.DokumentMalType;
-import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
 
 @ExtendWith(MockitoExtension.class)
 class DokumentKvitteringTjenesteTest {
@@ -35,9 +31,7 @@ class DokumentKvitteringTjenesteTest {
 
     @Test
     void publiserHistorikk() {
-        var kvittering = new DokumentKvitteringDto(UUID.randomUUID(), UUID.randomUUID(), "123", "123");
-
-        historikkTjeneste.sendKvittering(kvittering);
+        historikkTjeneste.sendKvittering(UUID.randomUUID(), UUID.randomUUID(), "123", "123");
         verify(behandlinger, times(1)).kvitterDokument(Mockito.any());
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/fpformidling/brevproduksjon/tjenester/historikk/DokumentKvitteringTjenesteTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.verify;
 
 import java.util.UUID;
 
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +35,7 @@ class DokumentKvitteringTjenesteTest {
 
     @Test
     void publiserHistorikk() {
-        var kvittering = new DokumentProdusertDto(UUID.randomUUID(), UUID.randomUUID(), DokumentMalType.INGEN_ENDRING.getKode(), "123", "123");
+        var kvittering = new DokumentKvitteringDto(UUID.randomUUID(), UUID.randomUUID(), "123", "123");
 
         historikkTjeneste.sendKvittering(kvittering);
         verify(behandlinger, times(1)).kvitterDokument(Mockito.any());


### PR DESCRIPTION
Malen lagres i fpsak i behandling_dokument_bestillt tabellen og henter derfra for historikk formål.