### PR TITLE
TFP-5890 ikke angi opprettet av enhet for maskinelle oppgaver

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/oppgave/OppgaverTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/oppgave/OppgaverTjeneste.java
@@ -35,7 +35,6 @@ public class OppgaverTjeneste {
                 no.nav.vedtak.felles.integrasjon.oppgave.v1.Prioritet.NORM, 1)
             .medAktoerId(behandling.getFagsakBackend().getAktørId().getId())
             .medSaksreferanse(behandling.getFagsakBackend().getSaksnummer().getVerdi())
-            .medOpprettetAvEnhetsnr(behandling.getBehandlendeEnhetId())
             .medTildeltEnhetsnr(behandling.getBehandlendeEnhetId())
             .medJournalpostId(journalpostId.getVerdi())
             .medBeskrivelse(oppgaveBeskrivelse)


### PR DESCRIPTION
Her opprettes kun ved manglende adresse. Kunne brukt type Behandle returpost 