### PR TITLE
TFP-5972 pdprequest-makeover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.7</version>
     </parent>
 
     <groupId>no.nav.foreldrepenger.fpformidling</groupId>
@@ -20,9 +20,9 @@
         <sonar.projectKey>navikt_fp-formidling</sonar.projectKey>
 
         <!-- Felles artefakter -->
-        <felles.version>7.4.13</felles.version>
-        <prosesstask.version>5.1.4</prosesstask.version>
-        <kontrakter.version>9.2.6</kontrakter.version>
+        <felles.version>7.4.15</felles.version>
+        <prosesstask.version>5.1.5</prosesstask.version>
+        <kontrakter.version>9.2.7</kontrakter.version>
     </properties>
 
     <!-- NB: Unngå å put scope (test, provided) i dependency management. Det har uheldige virkninger ved bruk av import og dependency (bruk composition
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>3.6.5</version>
+                <version>3.6.7</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Eksempel på at behandlingUuid er bærende og man må avgjøre om man stoler på at saksnummer matcher.
Eventuelt som nå - hente aktørId - eller hente saksnummer for behandlingUuid fra fpsak.