### PR TITLE
revert: syslog endring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,16 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.papertrailapp</groupId>
+            <artifactId>logback-syslog4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <!-- Swagger -->
         <dependency>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,18 +27,23 @@
                 <rootCauseFirst>false</rootCauseFirst>
             </throwableConverter>
         </encoder>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
     </appender>
 
     <!-- Sporbarhetslog -->
-    <appender name="auditLogger" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>audit.nais:6514</destination>
-        <writeBufferSize>128000</writeBufferSize>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>&lt;14&gt;%d{MMM dd HH:mm:ss} ${HOSTNAME} ${NAIS_APP_NAME}: %msg%n%n</pattern>
-        </encoder>
+    <appender name="auditLogger" class="com.papertrailapp.logback.Syslog4jAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%m%n%xEx</pattern>
+        </layout>
+
+        <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
+            <!-- remote system to log to -->
+            <host>audit.nais</host>
+            <!-- remote port to log to -->
+            <port>6514</port>
+            <ident>fpformidling</ident>
+            <!-- max log message length in bytes -->
+            <maxMessageLength>128000</maxMessageLength>
+        </syslogConfig>
     </appender>
 
     <!-- SecureLog -->


### PR DESCRIPTION
Den forrige fungerte ikke helt i kubernetes - men fungerte helt greit lokalt. Men fant ikke ut hvorfor.

logback-syslog4j er dessverre ikke vedlikeholdt og det ville være greit med en alternativ løsning.