### PR TITLE
Oppdaterer scope for dokdistfordeling

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/dokdist/DokdistRestKlient.java
@@ -21,7 +21,7 @@ import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 @ApplicationScoped
-@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, endpointProperty = "dokdist.rest.base.url", endpointDefault = "http://dokdistfordeling.teamdokumenthandtering/rest/v1", scopesProperty = "dokdist.scopes", scopesDefault = "api://prod-fss.teamdokumenthandtering.saf/.default")
+@RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, endpointProperty = "dokdist.rest.base.url", endpointDefault = "http://dokdistfordeling.teamdokumenthandtering/rest/v1", scopesProperty = "dokdist.scopes", scopesDefault = "api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default")
 class DokdistRestKlient implements Dokdist {
 
     private static final Logger LOG = LoggerFactory.getLogger(DokdistRestKlient.class);

--- a/src/main/resources/application-dev-fss.properties
+++ b/src/main/resources/application-dev-fss.properties
@@ -3,7 +3,7 @@
 pdl.scopes=api://dev-fss.pdl.pdl-api/.default
 
 dokdist.rest.base.url=http://dokdistfordeling.teamdokumenthandtering/rest/v1
-dokdist.scopes=api://dev-fss.teamdokumenthandtering.saf/.default
+dokdist.scopes=api://dev-fss.teamdokumenthandtering.dokdistfordeling/.default
 
 journalpost.rest.v1.url=http://dokarkiv.teamdokumenthandtering/rest/journalpostapi/v1/journalpost
 journalpost.scopes=api://dev-fss.teamdokumenthandtering.dokarkiv/.default

--- a/src/main/resources/application-prod-fss.properties
+++ b/src/main/resources/application-prod-fss.properties
@@ -3,7 +3,7 @@
 pdl.scopes=api://prod-fss.pdl.pdl-api/.default
 
 dokdist.rest.base.url=http://dokdistfordeling.teamdokumenthandtering/rest/v1
-dokdist.scopes=api://prod-fss.teamdokumenthandtering.saf/.default
+dokdist.scopes=api://prod-fss.teamdokumenthandtering.dokdistfordeling/.default
 
 journalpost.rest.v1.url=http://dokarkiv.teamdokumenthandtering/rest/journalpostapi/v1/journalpost
 journalpost.scopes=api://prod-fss.teamdokumenthandtering.dokarkiv/.default


### PR DESCRIPTION
* Fra saf-scope til dokdistfordeling-scope

Som annonsert: https://nav-it.slack.com/archives/C06Q2T7TCJG/p1754469824098999
> Vi gjør endringer på autentisering i dokdistfordeling, for å sørge for at autentisering med EntraID er implementert som tiltenkt. Pr i dag kalles distribuerJournalpost med EntraID tokens scopet mot SAF, hvor dokdistfordeling proxyer dette tokenet videre i kall til SAF. Vi ønsker på sikt å endre dette til av dokdistfordeling kun kan kalles med tokens som er scopet mot seg selv. Steg 1 av denne endringen innføres nå, hvor dokdistfordeling i en overgangsperiode vil akseptere tokens med enten saf- eller dokdistfordeling-scope. Dette innebærer at konsumenter ikke trenger å gjøre noe umiddelbart, men på sikt (helst så snart som mulig) må endre scope for tokenet de kaller dokdistfordeling med. Vi kommer til å bistå konsumenter med denne endringen. Liste med pre-autentiserte applikasjoner er populert for hvert miljø basert på kall mot distribuertJournalpost siste 7 dager.

Har dobbeltsjekket dokdistfordeling config og `prod-fss:teamforeldrepenger:fpformidling` ligger inne 😄 